### PR TITLE
Use import map for three.js modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -432,10 +432,18 @@ function switchMode(which){
 </script>
 
 <!-- ==================== 3D VIEWER (fixed) ==================== -->
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/npm/three@0.157.0/build/three.module.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.157.0/examples/jsm/"
+  }
+}
+</script>
 <script type="module">
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.157.0/build/three.module.js';
-import { STLLoader } from 'https://cdn.jsdelivr.net/npm/three@0.157.0/examples/jsm/loaders/STLLoader.js';
-import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.157.0/examples/jsm/controls/OrbitControls.js';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { STLLoader } from 'three/addons/loaders/STLLoader.js';
 
 const container = document.getElementById('preview3d');
 const canvas    = document.getElementById('stlCanvas');


### PR DESCRIPTION
## Summary
- add an import map for three.js so the viewer uses friendly module specifiers
- switch the 3D viewer script to import OrbitControls and STLLoader from the mapped specifiers

## Testing
- python3 -m http.server 8000
- playwright screenshot of the 3D preview

------
https://chatgpt.com/codex/tasks/task_e_68d67390d454832dae4e5fd0c08e0672