### PR TITLE
Restyle app with gold palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,37 +5,42 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Gold Design — Bracelet Builder (Pins + 3D)</title>
 <style>
-  :root{--bg:#0f1220;--panel:#151931;--ink:#e9ecf1;--muted:#9aa3b2;--radius:14px;--shadow:0 12px 28px rgba(0,0,0,.35)}
+  :root{--bg:#17120a;--bg2:#0f0b06;--card:#211a0e;--ink:#fff7e6;--muted:#e8d9b3;--gold:#d4af37;--gold2:#b88a1a;--radius:14px;--shadow:0 18px 36px rgba(0,0,0,.45)}
   *{box-sizing:border-box}html,body{height:100%}
   body{margin:0;background:
-    radial-gradient(1100px 500px at 10% -10%, #1b2142 0%, transparent 60%),
-    radial-gradient(800px 500px at 120% 10%, #172449 0%, transparent 60%), var(--bg);
+    radial-gradient(1100px 500px at 15% -15%, rgba(212,175,55,.16) 0%, transparent 60%),
+    radial-gradient(900px 600px at 120% 0%, rgba(184,138,26,.22) 0%, transparent 70%),
+    linear-gradient(160deg, var(--bg) 0%, var(--bg2) 100%);
     color:var(--ink);font:15.5px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Arial}
   .wrap{max-width:1200px;margin:28px auto;padding:0 16px;display:grid;gap:18px;grid-template-columns:1fr 1.35fr}
   @media (max-width:980px){.wrap{grid-template-columns:1fr}}
-  .card{background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));
-    border:1px solid rgba(255,255,255,.08);border-radius:var(--radius);box-shadow:var(--shadow);overflow:hidden}
-  .head{display:flex;align-items:center;justify-content:space-between;padding:16px 18px;border-bottom:1px solid rgba(255,255,255,.08)}
+  .card{background:linear-gradient(160deg,rgba(48,37,19,.86),var(--card));
+    border:1px solid rgba(212,175,55,.18);border-radius:var(--radius);box-shadow:var(--shadow);overflow:hidden}
+  .head{display:flex;align-items:center;justify-content:space-between;padding:16px 18px;border-bottom:1px solid rgba(212,175,55,.18);background:rgba(15,11,6,.45)}
   .head h1{margin:0;font-size:18px}.badge{font-size:12px;color:var(--muted)}
   .panel{padding:16px 18px}
   label{display:block;font-size:13px;color:var(--muted);margin-bottom:6px}
-  select,input{width:100%;padding:10px 12px;border-radius:10px;border:1px solid rgba(255,255,255,.15);background:#0f1428;color:var(--ink);outline:none}
+  select,input{width:100%;padding:10px 12px;border-radius:10px;border:1px solid rgba(212,175,55,.22);background:rgba(23,18,10,.75);color:var(--ink);outline:none;transition:border .2s,box-shadow .2s,background .2s}
+  select:focus,input:focus{border-color:var(--gold);box-shadow:0 0 0 2px rgba(212,175,55,.18);background:rgba(33,26,14,.85)}
   .grid2{display:grid;gap:12px;grid-template-columns:1fr 1fr}
   .rows{display:flex;flex-direction:column;gap:10px;margin-top:10px}
   .row{display:grid;grid-template-columns:1.2fr .7fr auto auto;gap:10px;align-items:end}
-  button{appearance:none;background:#10142a;color:var(--ink);border:1px solid rgba(255,255,255,.14);padding:10px 14px;border-radius:12px;cursor:pointer}
-  button:hover{border-color:rgba(255,255,255,.28)}
-  .summary{margin-top:12px;padding:12px 14px;border-radius:12px;background:#0e1223;border:1px solid rgba(255,255,255,.08);display:flex;justify-content:space-between;align-items:center;gap:10px}
-  .summary .w{color:#ffd37d}
+  button{appearance:none;background:linear-gradient(180deg,rgba(212,175,55,.16),rgba(184,138,26,.16));color:var(--ink);border:1px solid rgba(212,175,55,.35);padding:10px 14px;border-radius:12px;cursor:pointer;transition:border .2s,background .2s,color .2s}
+  button:hover{border-color:var(--gold);background:linear-gradient(180deg,rgba(212,175,55,.28),rgba(184,138,26,.2));color:var(--ink)}
+  .summary{margin-top:12px;padding:12px 14px;border-radius:12px;background:rgba(23,18,10,.85);border:1px solid rgba(212,175,55,.18);display:flex;justify-content:space-between;align-items:center;gap:10px}
+  .summary .w{color:var(--gold)}
   .buttons{display:flex;gap:10px;flex-wrap:wrap;margin-top:14px}
-  .preview{display:flex;align-items:center;justify-content:center;background:#0b0f1c;min-height:420px;position:relative}
+  .preview{display:flex;align-items:center;justify-content:center;background:
+    radial-gradient(600px 400px at 50% 0%, rgba(212,175,55,.12) 0%, transparent 70%),
+    var(--bg2);min-height:420px;position:relative}
   svg#stage{width:100%;height:100%;max-height:560px}
   .tabs{display:flex;gap:6px}
-  .tab{background:#10142a;border:1px solid rgba(255,255,255,.14);color:var(--ink);padding:6px 10px;border-radius:10px;cursor:pointer;font-size:12px}
-  .tab.active{border-color:#ffd37d;color:#ffd37d}
+  .tab{background:rgba(23,18,10,.75);border:1px solid rgba(212,175,55,.18);color:var(--muted);padding:6px 10px;border-radius:10px;cursor:pointer;font-size:12px;transition:border .2s,color .2s,background .2s}
+  .tab:hover{color:var(--ink);border-color:rgba(212,175,55,.28)}
+  .tab.active{border-color:var(--gold);color:var(--gold);background:rgba(33,26,14,.85)}
   #preview3d{display:none}
   #stlCanvas{width:100%;height:100%;max-height:560px;display:block}
-  .stlHud{position:absolute;left:12px;bottom:12px;display:flex;gap:8px;align-items:center;background:rgba(15,18,32,.6);border:1px solid rgba(255,255,255,.12);padding:8px 10px;border-radius:10px}
+  .stlHud{position:absolute;left:12px;bottom:12px;display:flex;gap:8px;align-items:center;background:rgba(21,15,8,.72);border:1px solid rgba(212,175,55,.2);padding:8px 10px;border-radius:10px}
   .stlHud select,.stlHud label{margin:0}
   .pin-dot{pointer-events:none}
 </style>
@@ -95,15 +100,15 @@
       <svg id="stage" viewBox="0 0 1080 400" role="img" aria-label="Bracelet preview">
         <defs id="defs">
           <linearGradient id="gold" x1="0" y1="0" x2="1" y2="1">
-            <stop offset="0%" stop-color="#ffe7a4"/><stop offset="35%" stop-color="#ffd36e"/>
-            <stop offset="60%" stop-color="#c3922e"/><stop offset="85%" stop-color="#fff2c6"/>
-            <stop offset="100%" stop-color="#e2b34a"/>
+            <stop offset="0%" stop-color="#fff7e6"/><stop offset="30%" stop-color="#f1d9a0"/>
+            <stop offset="60%" stop-color="#d4af37"/><stop offset="85%" stop-color="#b88a1a"/>
+            <stop offset="100%" stop-color="#f6e4bb"/>
           </linearGradient>
           <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
             <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#000" flood-opacity=".35"/>
           </filter>
         </defs>
-        <rect x="0" y="0" width="1080" height="400" fill="#0b0f1c"/>
+        <rect x="0" y="0" width="1080" height="400" fill="#0f0b06"/>
         <g id="bracelet"></g>
       </svg>
     </div>
@@ -166,7 +171,7 @@ function makeOption(t,v){ const o=document.createElement("option"); o.textConten
 function weightFor(name,type){ return WEIGHTS[name] ?? (type==="pendant" ? WEIGHTS.__default_pendant : WEIGHTS.__default_link); }
 const toNum = v => (v==null||v==="") ? null : (typeof v==="number" ? v : parseFloat(String(v)));
 function parseCoord(v, dim){ if(v==null) return null; const s=String(v).trim(); return s.endsWith("%") ? parseFloat(s)/100*dim : parseFloat(s); }
-function drawDot(parent,x,y,r=3){ const c=document.createElementNS("http://www.w3.org/2000/svg","circle"); c.setAttribute("cx",x); c.setAttribute("cy",y); c.setAttribute("r",r); c.setAttribute("fill","#ff47ff"); c.setAttribute("stroke","#fff"); c.setAttribute("stroke-width","1"); c.setAttribute("class","pin-dot"); parent.appendChild(c); }
+function drawDot(parent,x,y,r=3){ const c=document.createElementNS("http://www.w3.org/2000/svg","circle"); c.setAttribute("cx",x); c.setAttribute("cy",y); c.setAttribute("r",r); c.setAttribute("fill","#d4af37"); c.setAttribute("stroke","#fff7e6"); c.setAttribute("stroke-width","1"); c.setAttribute("class","pin-dot"); parent.appendChild(c); }
 
 /* Load SVG, scale, rotate, extract invisible pins */
 async function loadScaleRotate(dir, filename, targetH, rotateDeg){
@@ -282,7 +287,7 @@ function tintGold(node){
       const fill = el.getAttribute("fill");
       const stroke = el.getAttribute("stroke");
       if(!fill || fill!=="none") el.setAttribute("fill","url(#gold)");
-      if(stroke && stroke!=="none") el.setAttribute("stroke","#8a6a22");
+      if(stroke && stroke!=="none") el.setAttribute("stroke","#b88a1a");
       el.setAttribute("filter","url(#softShadow)");
     }
   }
@@ -452,7 +457,7 @@ const auto      = document.getElementById('stlAutoRotate');
 
 // Debug HUD (load status + size)
 const msg = document.createElement('div');
-msg.style.cssText = 'position:absolute;right:12px;bottom:12px;font:12px/1.3 system-ui;background:rgba(0,0,0,.45);border:1px solid rgba(255,255,255,.15);color:#fff;padding:6px 8px;border-radius:8px;pointer-events:none';
+msg.style.cssText = 'position:absolute;right:12px;bottom:12px;font:12px/1.3 system-ui;background:rgba(23,18,10,.78);border:1px solid rgba(212,175,55,.28);color:#fff7e6;padding:6px 8px;border-radius:8px;pointer-events:none';
 container.appendChild(msg);
 
 let renderer, scene, camera, controls, mesh, wire=false;
@@ -468,7 +473,7 @@ window.__resize3D = resize3D;
 
 function init(){
   scene = new THREE.Scene();
-  scene.background = new THREE.Color(0x0b0f1c);
+  scene.background = new THREE.Color(0x0f0b06);
 
   camera = new THREE.PerspectiveCamera(40, 1, 0.01, 5000);
   camera.position.set(0, 0, 10);


### PR DESCRIPTION
## Summary
- refresh the global color variables and component styles to use a rich gold and espresso palette
- update SVG gradient, preview panels, and UI adornments to reflect the new colors consistently
- adjust pin overlays, status messaging, and 3D viewport background to match the palette

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d677d3b688832db70d3814b050258d