### PR TITLE
Add back-side fill light to Three.js viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,6 +496,7 @@ function init(){
   const d1 = new THREE.DirectionalLight(0xffffff, 1.6); d1.position.set(6,7,10); scene.add(d1);
   const d2 = new THREE.DirectionalLight(0xfff4d2, 1.1); d2.position.set(-6,-4,5); scene.add(d2);
   const rim = new THREE.DirectionalLight(0xfff6e0, 0.9); rim.position.set(-3, 5, -4); scene.add(rim);
+  const fill = new THREE.DirectionalLight(0xfff0d8, 0.75); fill.position.set(0, 2, -8); scene.add(fill);
 
   // press "W" to toggle wireframe (debug)
   window.addEventListener('keydown', e=>{ if(e.key.toLowerCase()==='w'){ wire=!wire; if(mesh) mesh.material.wireframe = wire; } });


### PR DESCRIPTION
## Summary
- add a directional fill light behind the STL model to brighten the back face
- keep lighting balance so highlights remain intact while orbiting the camera

## Testing
- Manually loaded http://127.0.0.1:8000/index.html and confirmed 3D viewer lighting while orbiting


------
https://chatgpt.com/codex/tasks/task_e_68d696f16a9c832d9469394822afd2ef