### PR TITLE
Add theme selector and dynamic palettes

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,43 +5,151 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Gold Design — Bracelet Builder (Pins + 3D)</title>
 <style>
-  :root{--bg:#17120a;--bg2:#0f0b06;--card:#211a0e;--ink:#fff7e6;--muted:#e8d9b3;--gold:#d4af37;--gold2:#b88a1a;--radius:14px;--shadow:0 18px 36px rgba(0,0,0,.45)}
+  :root{--radius:14px;--shadow:0 18px 36px rgba(0,0,0,.45)}
+
+  html:not([data-theme]),
+  html[data-theme="navy"]{
+    --bg:#17120a;
+    --bg2:#0f0b06;
+    --card:#211a0e;
+    --card-overlay:rgba(48,37,19,.86);
+    --ink:#fff7e6;
+    --muted:#e8d9b3;
+    --gold:#d4af37;
+    --gold2:#b88a1a;
+    --border-soft:rgba(212,175,55,.18);
+    --border-strong:rgba(212,175,55,.35);
+    --control-border:rgba(212,175,55,.22);
+    --control-bg:rgba(23,18,10,.75);
+    --control-focus-bg:rgba(33,26,14,.85);
+    --control-focus-shadow:rgba(212,175,55,.18);
+    --head-bg:rgba(15,11,6,.45);
+    --summary-bg:rgba(23,18,10,.85);
+    --preview-glow:rgba(212,175,55,.12);
+    --tab-bg:rgba(23,18,10,.75);
+    --tab-active-bg:rgba(33,26,14,.85);
+    --hud-bg:rgba(21,15,8,.72);
+    --hud-border:rgba(212,175,55,.2);
+    --hud-text:#fff7e6;
+    --button-top:rgba(212,175,55,.16);
+    --button-bottom:rgba(184,138,26,.16);
+    --button-hover-top:rgba(212,175,55,.28);
+    --button-hover-bottom:rgba(184,138,26,.2);
+    --accent-radial-1:rgba(212,175,55,.16);
+    --accent-radial-2:rgba(184,138,26,.22);
+    --pin-fill:#d4af37;
+    --pin-stroke:#fff7e6;
+  }
+
+  html[data-theme="light"]{
+    --bg:#f6f2ea;
+    --bg2:#e4e9f3;
+    --card:#ffffff;
+    --card-overlay:rgba(255,255,255,.9);
+    --ink:#2b261c;
+    --muted:#706b60;
+    --gold:#c8892c;
+    --gold2:#a56a18;
+    --border-soft:rgba(200,137,44,.28);
+    --border-strong:rgba(200,137,44,.45);
+    --control-border:rgba(200,137,44,.34);
+    --control-bg:rgba(250,244,234,.92);
+    --control-focus-bg:rgba(255,250,243,.97);
+    --control-focus-shadow:rgba(200,137,44,.3);
+    --head-bg:rgba(242,234,220,.76);
+    --summary-bg:rgba(255,250,243,.92);
+    --preview-glow:rgba(200,137,44,.2);
+    --tab-bg:rgba(250,244,234,.88);
+    --tab-active-bg:rgba(255,250,243,.96);
+    --hud-bg:rgba(255,250,243,.96);
+    --hud-border:rgba(200,137,44,.38);
+    --hud-text:#2b261c;
+    --button-top:rgba(200,137,44,.22);
+    --button-bottom:rgba(165,106,24,.18);
+    --button-hover-top:rgba(200,137,44,.32);
+    --button-hover-bottom:rgba(165,106,24,.26);
+    --accent-radial-1:rgba(200,137,44,.16);
+    --accent-radial-2:rgba(165,106,24,.2);
+    --pin-fill:#c8892c;
+    --pin-stroke:#2b261c;
+  }
+
+  html[data-theme="plum"]{
+    --bg:#160b19;
+    --bg2:#341844;
+    --card:#2b1433;
+    --card-overlay:rgba(73,35,94,.72);
+    --ink:#f8ecff;
+    --muted:#d5c0ec;
+    --gold:#d794ff;
+    --gold2:#b162e4;
+    --border-soft:rgba(215,148,255,.32);
+    --border-strong:rgba(215,148,255,.48);
+    --control-border:rgba(215,148,255,.36);
+    --control-bg:rgba(41,20,51,.78);
+    --control-focus-bg:rgba(55,28,68,.86);
+    --control-focus-shadow:rgba(215,148,255,.26);
+    --head-bg:rgba(39,18,50,.65);
+    --summary-bg:rgba(41,20,51,.82);
+    --preview-glow:rgba(215,148,255,.18);
+    --tab-bg:rgba(41,20,51,.78);
+    --tab-active-bg:rgba(55,28,68,.88);
+    --hud-bg:rgba(45,22,58,.78);
+    --hud-border:rgba(215,148,255,.34);
+    --hud-text:#f8ecff;
+    --button-top:rgba(215,148,255,.2);
+    --button-bottom:rgba(177,98,228,.18);
+    --button-hover-top:rgba(215,148,255,.3);
+    --button-hover-bottom:rgba(177,98,228,.26);
+    --accent-radial-1:rgba(215,148,255,.2);
+    --accent-radial-2:rgba(177,98,228,.24);
+    --pin-fill:#d794ff;
+    --pin-stroke:#f8ecff;
+  }
+
   *{box-sizing:border-box}html,body{height:100%}
   body{margin:0;background:
-    radial-gradient(1100px 500px at 15% -15%, rgba(212,175,55,.16) 0%, transparent 60%),
-    radial-gradient(900px 600px at 120% 0%, rgba(184,138,26,.22) 0%, transparent 70%),
+    radial-gradient(1100px 500px at 15% -15%, var(--accent-radial-1) 0%, transparent 60%),
+    radial-gradient(900px 600px at 120% 0%, var(--accent-radial-2) 0%, transparent 70%),
     linear-gradient(160deg, var(--bg) 0%, var(--bg2) 100%);
-    color:var(--ink);font:15.5px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Arial}
+    color:var(--ink);font:15.5px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Arial;transition:color .3s ease, background .3s ease}
   .wrap{max-width:1200px;margin:28px auto;padding:0 16px;display:grid;gap:18px;grid-template-columns:1fr 1.35fr}
   @media (max-width:980px){.wrap{grid-template-columns:1fr}}
-  .card{background:linear-gradient(160deg,rgba(48,37,19,.86),var(--card));
-    border:1px solid rgba(212,175,55,.18);border-radius:var(--radius);box-shadow:var(--shadow);overflow:hidden}
-  .head{display:flex;align-items:center;justify-content:space-between;padding:16px 18px;border-bottom:1px solid rgba(212,175,55,.18);background:rgba(15,11,6,.45)}
-  .head h1{margin:0;font-size:18px}.badge{font-size:12px;color:var(--muted)}
+  .card{background:linear-gradient(160deg,var(--card-overlay),var(--card));
+    border:1px solid var(--border-soft);border-radius:var(--radius);box-shadow:var(--shadow);overflow:hidden;transition:background .3s ease,border-color .3s ease,box-shadow .3s ease}
+  .head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:16px 18px;border-bottom:1px solid var(--border-soft);background:var(--head-bg)}
+  .head h1{margin:0;font-size:18px}
+  .headPrimary{display:flex;flex-direction:column;gap:4px}
+  .badge{font-size:12px;color:var(--muted)}
+  .themePicker{display:inline-flex;align-items:center;gap:8px;font-size:12px;color:var(--muted)}
+  .themePicker span{white-space:nowrap}
   .panel{padding:16px 18px}
   label{display:block;font-size:13px;color:var(--muted);margin-bottom:6px}
-  select,input{width:100%;padding:10px 12px;border-radius:10px;border:1px solid rgba(212,175,55,.22);background:rgba(23,18,10,.75);color:var(--ink);outline:none;transition:border .2s,box-shadow .2s,background .2s}
-  select:focus,input:focus{border-color:var(--gold);box-shadow:0 0 0 2px rgba(212,175,55,.18);background:rgba(33,26,14,.85)}
+  select,input{width:100%;padding:10px 12px;border-radius:10px;border:1px solid var(--control-border);background:var(--control-bg);color:var(--ink);outline:none;transition:border .2s,box-shadow .2s,background .2s,color .3s ease}
+  select:focus,input:focus{border-color:var(--gold);box-shadow:0 0 0 2px var(--control-focus-shadow);background:var(--control-focus-bg)}
+  .themePicker select{width:auto;min-width:120px;padding:6px 10px;font-size:12px}
   .grid2{display:grid;gap:12px;grid-template-columns:1fr 1fr}
   .rows{display:flex;flex-direction:column;gap:10px;margin-top:10px}
   .row{display:grid;grid-template-columns:1.2fr .7fr auto auto;gap:10px;align-items:end}
-  button{appearance:none;background:linear-gradient(180deg,rgba(212,175,55,.16),rgba(184,138,26,.16));color:var(--ink);border:1px solid rgba(212,175,55,.35);padding:10px 14px;border-radius:12px;cursor:pointer;transition:border .2s,background .2s,color .2s}
-  button:hover{border-color:var(--gold);background:linear-gradient(180deg,rgba(212,175,55,.28),rgba(184,138,26,.2));color:var(--ink)}
-  .summary{margin-top:12px;padding:12px 14px;border-radius:12px;background:rgba(23,18,10,.85);border:1px solid rgba(212,175,55,.18);display:flex;justify-content:space-between;align-items:center;gap:10px}
+  button{appearance:none;background:linear-gradient(180deg,var(--button-top),var(--button-bottom));color:var(--ink);border:1px solid var(--border-strong);padding:10px 14px;border-radius:12px;cursor:pointer;transition:border .2s,background .2s,color .2s}
+  button:hover{border-color:var(--gold);background:linear-gradient(180deg,var(--button-hover-top),var(--button-hover-bottom));color:var(--ink)}
+  .summary{margin-top:12px;padding:12px 14px;border-radius:12px;background:var(--summary-bg);border:1px solid var(--border-soft);display:flex;justify-content:space-between;align-items:center;gap:10px}
   .summary .w{color:var(--gold)}
   .buttons{display:flex;gap:10px;flex-wrap:wrap;margin-top:14px}
   .preview{display:flex;align-items:center;justify-content:center;background:
-    radial-gradient(600px 400px at 50% 0%, rgba(212,175,55,.12) 0%, transparent 70%),
-    var(--bg2);min-height:420px;position:relative}
+    radial-gradient(600px 400px at 50% 0%, var(--preview-glow) 0%, transparent 70%),
+    var(--bg2);min-height:420px;position:relative;transition:background .3s ease}
   svg#stage{width:100%;height:100%;max-height:560px}
+  #stage [data-role="background"]{fill:var(--bg2);transition:fill .3s ease}
   .tabs{display:flex;gap:6px}
-  .tab{background:rgba(23,18,10,.75);border:1px solid rgba(212,175,55,.18);color:var(--muted);padding:6px 10px;border-radius:10px;cursor:pointer;font-size:12px;transition:border .2s,color .2s,background .2s}
-  .tab:hover{color:var(--ink);border-color:rgba(212,175,55,.28)}
-  .tab.active{border-color:var(--gold);color:var(--gold);background:rgba(33,26,14,.85)}
+  .tab{background:var(--tab-bg);border:1px solid var(--border-soft);color:var(--muted);padding:6px 10px;border-radius:10px;cursor:pointer;font-size:12px;transition:border .2s,color .2s,background .2s}
+  .tab:hover{color:var(--ink);border-color:var(--gold)}
+  .tab.active{border-color:var(--gold);color:var(--gold);background:var(--tab-active-bg)}
   #preview3d{display:none}
   #stlCanvas{width:100%;height:100%;max-height:560px;display:block}
-  .stlHud{position:absolute;left:12px;bottom:12px;display:flex;gap:8px;align-items:center;background:rgba(21,15,8,.72);border:1px solid rgba(212,175,55,.2);padding:8px 10px;border-radius:10px}
+  .stlHud{position:absolute;left:12px;bottom:12px;display:flex;gap:8px;align-items:center;background:var(--hud-bg);border:1px solid var(--hud-border);padding:8px 10px;border-radius:10px;color:var(--hud-text);backdrop-filter:blur(8px);transition:background .3s ease,border-color .3s ease,color .3s ease}
   .stlHud select,.stlHud label{margin:0}
+  .stlStatus{position:absolute;right:12px;bottom:12px;font:12px/1.3 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Arial;background:var(--hud-bg);border:1px solid var(--hud-border);color:var(--hud-text);padding:6px 8px;border-radius:8px;pointer-events:none;transition:background .3s ease,border-color .3s ease,color .3s ease}
   .pin-dot{pointer-events:none}
 </style>
 </head>
@@ -50,8 +158,18 @@
   <!-- LEFT -->
   <section class="card">
     <div class="head">
-      <h1>Bracelet Builder</h1>
-      <span class="badge">Pin snapping · horizontal SVGs</span>
+      <div class="headPrimary">
+        <h1>Bracelet Builder</h1>
+        <span class="badge">Pin snapping · horizontal SVGs</span>
+      </div>
+      <div class="themePicker">
+        <span>Theme</span>
+        <select id="themeSelect" aria-label="Select theme">
+          <option value="navy">Navy</option>
+          <option value="light">Light</option>
+          <option value="plum">Plum</option>
+        </select>
+      </div>
     </div>
     <div class="panel">
       <div class="grid2">
@@ -108,7 +226,7 @@
             <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#000" flood-opacity=".35"/>
           </filter>
         </defs>
-        <rect x="0" y="0" width="1080" height="400" fill="#0f0b06"/>
+        <rect x="0" y="0" width="1080" height="400" fill="#0f0b06" data-role="background"/>
         <g id="bracelet"></g>
       </svg>
     </div>
@@ -133,6 +251,26 @@
 <script>
 "use strict";
 
+const THEMES = ["navy", "light", "plum"];
+const THEME_KEY = "bracelet-builder-theme";
+const DEFAULT_THEME = "navy";
+
+function applyTheme(theme){
+  const next = THEMES.includes(theme) ? theme : DEFAULT_THEME;
+  document.documentElement.dataset.theme = next;
+  if(typeof window.__update3DTheme === "function"){
+    window.__update3DTheme(next);
+  }
+  return next;
+}
+
+let currentTheme = DEFAULT_THEME;
+try{
+  const stored = (typeof localStorage !== "undefined") ? localStorage.getItem(THEME_KEY) : null;
+  if(stored) currentTheme = stored;
+}catch(_){ currentTheme = DEFAULT_THEME; }
+currentTheme = applyTheme(currentTheme);
+
 /* Exact asset names */
 const PENDANTS = ["Infinity Knot 1.svg"];
 const LINKS    = ["halo link.svg"];
@@ -152,6 +290,7 @@ const WEIGHTS = {
 const stage = document.getElementById("stage");
 const defs = document.getElementById("defs");
 const bracelet = document.getElementById("bracelet");
+const selTheme = document.getElementById("themeSelect");
 const selPendant = document.getElementById("pendant");
 const inpPendantScale = document.getElementById("pendantScale");
 const rowsBox = document.getElementById("rows");
@@ -171,7 +310,17 @@ function makeOption(t,v){ const o=document.createElement("option"); o.textConten
 function weightFor(name,type){ return WEIGHTS[name] ?? (type==="pendant" ? WEIGHTS.__default_pendant : WEIGHTS.__default_link); }
 const toNum = v => (v==null||v==="") ? null : (typeof v==="number" ? v : parseFloat(String(v)));
 function parseCoord(v, dim){ if(v==null) return null; const s=String(v).trim(); return s.endsWith("%") ? parseFloat(s)/100*dim : parseFloat(s); }
-function drawDot(parent,x,y,r=3){ const c=document.createElementNS("http://www.w3.org/2000/svg","circle"); c.setAttribute("cx",x); c.setAttribute("cy",y); c.setAttribute("r",r); c.setAttribute("fill","#d4af37"); c.setAttribute("stroke","#fff7e6"); c.setAttribute("stroke-width","1"); c.setAttribute("class","pin-dot"); parent.appendChild(c); }
+function drawDot(parent,x,y,r=3,colors){
+  const c=document.createElementNS("http://www.w3.org/2000/svg","circle");
+  c.setAttribute("cx",x);
+  c.setAttribute("cy",y);
+  c.setAttribute("r",r);
+  c.setAttribute("fill",colors?.fill || "#d4af37");
+  c.setAttribute("stroke",colors?.stroke || "#fff7e6");
+  c.setAttribute("stroke-width","1");
+  c.setAttribute("class","pin-dot");
+  parent.appendChild(c);
+}
 
 /* Load SVG, scale, rotate, extract invisible pins */
 async function loadScaleRotate(dir, filename, targetH, rotateDeg){
@@ -238,6 +387,17 @@ async function loadScaleRotate(dir, filename, targetH, rotateDeg){
 
   addRow({type:LINKS[0], qty:6}); // one link row by default
 
+  if(selTheme){
+    selTheme.value = THEMES.includes(selTheme.value) ? selTheme.value : currentTheme;
+    if(selTheme.value !== currentTheme) selTheme.value = currentTheme;
+    selTheme.addEventListener("change", e=>{
+      const chosen = applyTheme(e.target.value);
+      currentTheme = chosen;
+      try{ if(typeof localStorage !== "undefined") localStorage.setItem(THEME_KEY, chosen); }catch(_){/* ignore */}
+      render();
+    });
+  }
+
   btnAddRow.addEventListener("click", ()=>addRow());
   selPendant.addEventListener("change", render);
   inpPendantScale.addEventListener("input", render);
@@ -299,6 +459,15 @@ async function render(){
   const token=++lastToken;
   clear(bracelet);
 
+  const themeStyles = getComputedStyle(document.documentElement);
+  const bg2 = (themeStyles.getPropertyValue("--bg2") || "").trim() || "#0f0b06";
+  const stageBg = stage.querySelector('[data-role="background"]');
+  if(stageBg) stageBg.setAttribute("fill", bg2);
+  const pinColors = {
+    fill: (themeStyles.getPropertyValue("--pin-fill") || "").trim() || "#d4af37",
+    stroke: (themeStyles.getPropertyValue("--pin-stroke") || "").trim() || "#fff7e6"
+  };
+
   const rows = readRows();
   const pendantName = selPendant.value;
   const pendantH = Math.max(20, Math.min(200, inpPendantScale.valueAsNumber||160));
@@ -352,8 +521,8 @@ async function render(){
   tintGold(pendantPack.node); gp.appendChild(pendantPack.node); bracelet.appendChild(gp);
 
   if (chkPins?.checked && pendantPack.pins?.L && pendantPack.pins?.R) {
-    drawDot(dbg, gpX + pendantPack.pins.L.x, gpY + pendantPack.pins.L.y);
-    drawDot(dbg, gpX + pendantPack.pins.R.x, gpY + pendantPack.pins.R.y);
+    drawDot(dbg, gpX + pendantPack.pins.L.x, gpY + pendantPack.pins.L.y, 3, pinColors);
+    drawDot(dbg, gpX + pendantPack.pins.R.x, gpY + pendantPack.pins.R.y, 3, pinColors);
   }
 
   // Left side
@@ -371,7 +540,7 @@ async function render(){
     const node = d.node.cloneNode(true); tintGold(node);
     g.appendChild(node); bracelet.appendChild(g);
 
-    if(chkPins?.checked && L && R){ drawDot(dbg, tx+L.x, ty+L.y); drawDot(dbg, tx+R.x, ty+R.y); }
+    if(chkPins?.checked && L && R){ drawDot(dbg, tx+L.x, ty+L.y, 3, pinColors); drawDot(dbg, tx+R.x, ty+R.y, 3, pinColors); }
     anchorL = L && R ? {x: tx + L.x, y: ty + L.y} : {x: tx, y: midY};
   }
 
@@ -390,7 +559,7 @@ async function render(){
     const node = d.node.cloneNode(true); tintGold(node);
     g.appendChild(node); bracelet.appendChild(g);
 
-    if(chkPins?.checked && L && R){ drawDot(dbg, tx+L.x, ty+L.y); drawDot(dbg, tx+R.x, ty+R.y); }
+    if(chkPins?.checked && L && R){ drawDot(dbg, tx+L.x, ty+L.y, 3, pinColors); drawDot(dbg, tx+R.x, ty+R.y, 3, pinColors); }
     anchorR = L && R ? {x: tx + R.x, y: ty + R.y} : {x: tx + d.width, y: midY};
   }
 
@@ -457,10 +626,10 @@ const auto      = document.getElementById('stlAutoRotate');
 
 // Debug HUD (load status + size)
 const msg = document.createElement('div');
-msg.style.cssText = 'position:absolute;right:12px;bottom:12px;font:12px/1.3 system-ui;background:rgba(23,18,10,.78);border:1px solid rgba(212,175,55,.28);color:#fff7e6;padding:6px 8px;border-radius:8px;pointer-events:none';
+msg.className = 'stlStatus';
 container.appendChild(msg);
 
-let renderer, scene, camera, controls, mesh, wire=false;
+let renderer, scene, camera, controls, mesh, meshMaterial, wire=false;
 
 init();
 loadCurrent();
@@ -471,9 +640,33 @@ window.addEventListener('resize', resize3D);
 // let non-module switcher force-resize when tab opens
 window.__resize3D = resize3D;
 
+function updateViewerTheme(){
+  if(!scene) return;
+  const styles = getComputedStyle(document.documentElement);
+  const bg = (styles.getPropertyValue('--bg2') || '').trim() || '#0f0b06';
+  let bgColor;
+  try{ bgColor = new THREE.Color(bg); }
+  catch(_){ bgColor = new THREE.Color(0x0f0b06); }
+  scene.background = bgColor;
+  if(renderer){ renderer.setClearColor(bgColor, 1); }
+
+  const accent = (styles.getPropertyValue('--gold') || '').trim() || '#d4af37';
+  if(meshMaterial){ meshMaterial.color.set(accent); }
+
+  if(msg){
+    const hudBg = (styles.getPropertyValue('--hud-bg') || '').trim() || 'rgba(21,15,8,.72)';
+    const hudBorder = (styles.getPropertyValue('--hud-border') || '').trim() || 'rgba(212,175,55,.2)';
+    const hudText = (styles.getPropertyValue('--hud-text') || '').trim() || '#fff7e6';
+    msg.style.backgroundColor = hudBg;
+    msg.style.borderColor = hudBorder;
+    msg.style.color = hudText;
+  }
+}
+
+window.__update3DTheme = updateViewerTheme;
+
 function init(){
   scene = new THREE.Scene();
-  scene.background = new THREE.Color(0x0f0b06);
 
   camera = new THREE.PerspectiveCamera(40, 1, 0.01, 5000);
   camera.position.set(0, 0, 10);
@@ -505,6 +698,7 @@ function init(){
   window.addEventListener('keydown', e=>{ if(e.key.toLowerCase()==='w'){ wire=!wire; if(mesh) mesh.material.wireframe = wire; } });
 
   resize3D();
+  updateViewerTheme();
   animate();
 }
 
@@ -523,7 +717,7 @@ async function loadCurrent(){
     const url = raw.replace(/ /g, '%20');       // safe path (spaces → %20)
     msg.textContent = 'Loading… ' + raw;
 
-    if(mesh){ scene.remove(mesh); mesh.geometry.dispose(); mesh.material.dispose(); mesh=null; }
+    if(mesh){ scene.remove(mesh); mesh.geometry.dispose(); mesh.material.dispose(); mesh=null; meshMaterial=null; }
 
     const loader = new STLLoader();
     const geom = await loader.loadAsync(url);
@@ -537,8 +731,11 @@ async function loadCurrent(){
     mat.wireframe = wire;
 
     mesh = new THREE.Mesh(geom, mat);
+    meshMaterial = mat;
     scene.add(mesh);
     fitToView(mesh);
+
+    updateViewerTheme();
 
     const box = new THREE.Box3().setFromObject(mesh);
     const sz  = new THREE.Vector3(); box.getSize(sz);


### PR DESCRIPTION
## Summary
- introduce theme-specific CSS variables along with navy, light, and plum palettes
- add a theme selector to the builder header and persist the user choice across sessions
- synchronize the 2D and 3D previews with theme changes, including STL background and pin colors

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d6a168f5d4832d8cf1cca49511c8c0