### PR TITLE
Ensure light theme loads by default and normalize dark theme storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,7 @@
 <style>
   :root{--radius:14px;--shadow:0 18px 36px rgba(0,0,0,.45)}
 
-  html:not([data-theme]),
-  html[data-theme="navy"]{
+  html[data-theme="dark"]{
     --bg:#17120a;
     --bg2:#0f0b06;
     --card:#211a0e;
@@ -41,6 +40,7 @@
     --pin-stroke:#fff7e6;
   }
 
+  html:not([data-theme]),
   html[data-theme="light"]{
     --bg:#f6f2ea;
     --bg2:#e4e9f3;
@@ -165,7 +165,7 @@
       <div class="themePicker">
         <span>Theme</span>
         <select id="themeSelect" aria-label="Select theme">
-          <option value="navy">Navy</option>
+          <option value="dark">Dark</option>
           <option value="light">Light</option>
           <option value="plum">Plum</option>
         </select>
@@ -251,16 +251,20 @@
 <script>
 "use strict";
 
-const THEMES = ["navy", "light", "plum"];
+const THEMES = ["light", "dark", "plum"];
 const THEME_KEY = "bracelet-builder-theme";
-const DEFAULT_THEME = "navy";
+const DEFAULT_THEME = "light";
 
 function applyTheme(theme){
-  const next = THEMES.includes(theme) ? theme : DEFAULT_THEME;
+  const normalized = theme === "navy" ? "dark" : theme;
+  const next = THEMES.includes(normalized) ? normalized : DEFAULT_THEME;
   document.documentElement.dataset.theme = next;
   if(typeof window.__update3DTheme === "function"){
     window.__update3DTheme(next);
   }
+  try{
+    if(typeof localStorage !== "undefined") localStorage.setItem(THEME_KEY, next);
+  }catch(_){/* ignore */}
   return next;
 }
 
@@ -393,7 +397,6 @@ async function loadScaleRotate(dir, filename, targetH, rotateDeg){
     selTheme.addEventListener("change", e=>{
       const chosen = applyTheme(e.target.value);
       currentTheme = chosen;
-      try{ if(typeof localStorage !== "undefined") localStorage.setItem(THEME_KEY, chosen); }catch(_){/* ignore */}
       render();
     });
   }


### PR DESCRIPTION
## Summary
- rename the navy palette to dark and keep light as the initial theme
- update the theme picker options and theme list to reflect the new dark entry
- normalize stored navy values to dark while persisting the selected theme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6ccfc1718832d94c49b8daf1b76a9