### PR TITLE
Fix 3D pendant pin alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1089,9 +1089,10 @@ function ratioToLocal(ratio, metrics){
   const rx = clamp(ratio?.x);
   const ry = clamp(ratio?.y);
   const rz = clamp(ratio?.z);
+  const invertedY = 1 - ry;
   return new THREE.Vector3(
     box.min.x + size.x * rx,
-    box.min.y + size.y * ry,
+    box.min.y + size.y * invertedY,
     box.min.z + size.z * rz
   );
 }


### PR DESCRIPTION
## Summary
- invert the pin Y ratio when projecting SVG pin metadata into STL space so pendant pins align with links in 3D

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8e231d8a0832db20ec1360ea1b316