### PR TITLE
Add builder support for new pendant SVGs

### DIFF
--- a/index.html
+++ b/index.html
@@ -946,7 +946,12 @@ try{
 currentTheme = applyTheme(currentTheme);
 
 /* Exact asset names */
-const PENDANTS = ["Infinity Knot 1.svg"];
+const PENDANTS = [
+  "Infinity Knot 1.svg",
+  "butterlfy 1.svg",
+  "butterlfy 2.svg",
+  "turtle 1.svg"
+];
 const LINKS    = ["halo link.svg", "gold circle link.svg"];
 
 /* Locks (terminal, left end only) */
@@ -1007,6 +1012,9 @@ const PENDANT_MASK_ID = "pendantCutMask";
 /* Placeholder weights */
 const WEIGHTS = {
   "Infinity Knot 1.svg": 0.32,
+  "butterlfy 1.svg": 0.30,
+  "butterlfy 2.svg": 0.30,
+  "turtle 1.svg": 0.30,
   "halo link.svg": 0.10,
   "gold circle link.svg": 0.10,
   "dolphin fish lock.svg": 0.12,

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -28,7 +28,7 @@ function assert(condition, message){
 assert(/const\s+PENDANT_MASK_ID\s*=\s*"pendantCutMask"/.test(html), 'Pendant mask ID constant is defined');
 assert(/function\s+clonePendantForMask\s*\(/.test(html), 'clonePendantForMask helper exists');
 assert(/mask\.setAttribute\(\"id\",\s*PENDANT_MASK_ID\)/.test(html), 'Mask definition attaches pendant mask ID');
-assert(/front\.setAttribute\(\"mask\",\s*pendantMaskUrl\)/.test(html), 'Front link clone uses the pendant mask');
+assert(/stackOverMasked\.setAttribute\(\"mask\",\s*pendantMaskUrl\)/.test(html), 'Masked overlay applies the pendant mask');
 assert(html.includes('defs.querySelectorAll(`[data-role="pendant-mask"]`).forEach(n=>n.remove());'), 'Old pendant masks are cleaned before each render');
 
 if(failed){


### PR DESCRIPTION
## Summary
- add the newly uploaded pendant SVGs to the builder's pendant list and weight map so they are selectable
- adjust the pendant mask sanity check to match the current mask application logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e131d69324832abe6c10fb0193d72f