### PR TITLE
Simplify builder preview layout and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -514,41 +514,6 @@
       </div>
       <div style="margin-top:8px"><button id="addRow" data-i18n="builder.addRow">+ Add link type</button></div>
 
-      <!-- Canvas / Zoom -->
-      <div class="stack" style="margin-top:16px">
-        <label class="lbl" for="canvasPreset">Canvas size</label>
-        <select id="canvasPreset">
-          <option value="1080x320">Bracelet (1080×320)</option>
-          <option value="1280x420">Keychain (1280×420)</option>
-          <option value="1920x520">Necklace (1920×520)</option>
-        </select>
-        <div class="zoombar">
-          <button type="button" id="zoomFit">Fit</button>
-          <button type="button" id="zoomOut">–</button>
-          <button type="button" id="zoomIn">+</button>
-          <span id="zoomLabel">100%</span>
-        </div>
-      </div>
-
-      <!-- Real-world length parameters -->
-      <div class="stack" style="margin-top:16px">
-        <label class="lbl" for="lenPendantMm">Pendant length (mm)</label>
-        <input id="lenPendantMm" type="number" min="0" step="0.1" value="50">
-        <label class="lbl" for="lenLockMm">Lock length (mm)</label>
-        <input id="lenLockMm" type="number" min="0" step="0.1" value="5">
-      </div>
-
-      <!-- Per-row link length (mm) -->
-      <div class="stack" id="rowLenContainer" style="margin-top:16px"></div>
-
-      <!-- Target length + auto-fill -->
-      <div class="stack" style="margin-top:16px">
-        <label class="lbl" for="targetLenCm">Target total length (cm)</label>
-        <input id="targetLenCm" type="number" min="0" step="0.1" placeholder="e.g., 18.0">
-        <button type="button" id="btnAutofill">Auto-fill qty</button>
-        <div id="lenReadout" class="muted"></div>
-      </div>
-
       <div class="grid2" style="margin-top:16px">
         <div>
           <label for="metalPreset" data-i18n="builder.metal">Metal &amp; purity</label>
@@ -564,7 +529,6 @@
           <div><strong data-i18n="builder.summary.h">Estimated Weight</strong></div>
           <span class="w" id="totalWeight">0.00 g</span>
           <div class="badge" id="materialDetails" data-i18n="builder.summary.details">Select a metal profile to view density, price &amp; narrative.</div>
-          <div id="summary-length">Length: <span id="summaryLenVal">—</span></div>
         </div>
         <div class="summary-stats">
           <div class="stat">
@@ -593,15 +557,23 @@
   <section class="card">
     <div class="head">
       <h1 data-i18n="builder.preview.h">Preview</h1>
-      <div class="tabs">
-        <button class="tab active" id="tab2d" data-i18n="builder.preview.tab2d">2D</button>
-        <button class="tab" id="tab3d" data-i18n="builder.preview.tab3d">3D (STL)</button>
+      <div style="display:flex;gap:10px;align-items:center">
+        <div class="tabs">
+          <button class="tab active" id="tab2d" data-i18n="builder.preview.tab2d">2D</button>
+          <button class="tab" id="tab3d" data-i18n="builder.preview.tab3d">3D (STL)</button>
+        </div>
+        <div class="zoombar" style="display:flex;gap:6px;align-items:center">
+          <button type="button" id="zoomFit">Fit</button>
+          <button type="button" id="zoomOut">–</button>
+          <button type="button" id="zoomIn">+</button>
+          <span id="zoomLabel">100%</span>
+        </div>
       </div>
     </div>
 
     <!-- 2D -->
     <div class="preview" id="preview2d">
-      <svg id="preview" width="100%" height="100%" viewBox="0 0 1080 320" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Bracelet preview">
+      <svg id="preview" width="100%" height="100%" viewBox="0 0 1920 520" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Bracelet preview">
         <defs id="defs">
           <!-- 18K: warm classic gold -->
           <linearGradient id="gold18" x1="0" y1="0" x2="1" y2="1">
@@ -634,7 +606,7 @@
           </filter>
         </defs>
         <g id="viewport" transform="matrix(1 0 0 1 0 0)">
-          <rect x="0" y="0" width="1080" height="320" fill="#0f0b06" data-role="background"/>
+          <rect x="0" y="0" width="1920" height="520" fill="#0f0b06" data-role="background"/>
           <g id="bracelet"></g>
         </g>
       </svg>
@@ -727,8 +699,8 @@ window.addEventListener('hcj:lang', onLanguageChange);
 const THEMES = ["light", "dark", "plum", "custom"];
 const THEME_KEY = window.__HCJ_THEME_KEY || "hcj-theme";
 const DEFAULT_THEME = document.documentElement.dataset.theme || "light";
-let STAGE_W = 1080;
-let STAGE_H = 320; // compact height
+let STAGE_W = 1920;
+let STAGE_H = 520;
 const STORAGE_KEYS = {
   session: 'hcj-builder-session',
   wishlist: 'hcj-builder-wishlist',
@@ -737,13 +709,6 @@ const STORAGE_KEYS = {
 };
 const BASE_DENSITY = 15.6; // 18K heritage gold baseline (g/cm^3)
 const BASE_WRIST_CM = 18;
-
-/* ---------- Canvas size presets ---------- */
-const PRESETS = {
-  "1080x320": [1080, 320],
-  "1280x420": [1280, 420],
-  "1920x520": [1920, 520]
-};
 
 function setCanvasSize(w, h){
   STAGE_W = w; STAGE_H = h;
@@ -806,14 +771,6 @@ function zoom(delta){
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  const presetSel = document.getElementById('canvasPreset');
-  if(presetSel){
-    presetSel.addEventListener('change', e => {
-      const [w, h] = PRESETS[e.target.value] || [STAGE_W, STAGE_H];
-      setCanvasSize(w, h);
-      render();
-    });
-  }
   document.getElementById('zoomFit')?.addEventListener('click', () => fitViewport());
   document.getElementById('zoomIn')?.addEventListener('click', () => zoom(+1));
   document.getElementById('zoomOut')?.addEventListener('click', () => zoom(-1));
@@ -1079,120 +1036,7 @@ const wishlistCTA = document.getElementById("wishlistCTA");
 const selLighting = document.getElementById("lightingPreset");
 const cameraButtons = Array.from(document.querySelectorAll('.cameraControls button'));
 
-/* ---------- Lengths (mm) ---------- */
-let LEN_PENDANT_MM = 50;
-let LEN_LOCK_MM = 5;
-let perRowLenMm = [];
 let currentRows = [];
-
-function ensureRowLenInputs(){
-  const box = document.getElementById('rowLenContainer');
-  if(!box) return;
-  box.innerHTML = '';
-  perRowLenMm = perRowLenMm.slice(0, currentRows.length);
-  currentRows.forEach((row, i) => {
-    if(perRowLenMm[i] == null) perRowLenMm[i] = 10;
-    const wrap = document.createElement('div');
-    wrap.className = 'row-len';
-    wrap.innerHTML = `<span>Row ${i + 1}</span><input data-row="${i}" class="lenLinkMm" type="number" min="0" step="0.1" value="${perRowLenMm[i]}">`;
-    box.appendChild(wrap);
-  });
-  box.querySelectorAll('.lenLinkMm').forEach(inp => {
-    inp.addEventListener('input', e => {
-      const idx = Number(e.target.dataset.row);
-      perRowLenMm[idx] = parseFloat(e.target.value || '0') || 0;
-      updateLengthReadout();
-    });
-  });
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-  const p = document.getElementById('lenPendantMm');
-  const l = document.getElementById('lenLockMm');
-  if(p){
-    p.value = LEN_PENDANT_MM;
-    p.addEventListener('input', () => {
-      LEN_PENDANT_MM = parseFloat(p.value || '0') || 0;
-      updateLengthReadout();
-    });
-  }
-  if(l){
-    l.value = LEN_LOCK_MM;
-    l.addEventListener('input', () => {
-      LEN_LOCK_MM = parseFloat(l.value || '0') || 0;
-      updateLengthReadout();
-    });
-  }
-
-  const btn = document.getElementById('btnAutofill');
-  const tgt = document.getElementById('targetLenCm');
-  if(btn){
-    btn.addEventListener('click', () => {
-      const targetCm = parseFloat(tgt?.value || '0') || 0;
-      if(targetCm <= 0) return;
-      autofillQuantities(targetCm * 10);
-      render();
-    });
-  }
-  tgt?.addEventListener('input', () => updateLengthReadout());
-});
-
-function computeTotalLengthMm(){
-  let mm = 0;
-  currentRows.forEach((row, i) => {
-    const perLink = perRowLenMm[i] ?? 0;
-    mm += ((row.qty || 0) * 2) * perLink;
-  });
-  mm += LEN_PENDANT_MM;
-  if((selLock?.value || '').trim()) mm += LEN_LOCK_MM;
-  return mm;
-}
-
-function updateLengthReadout(){
-  const el = document.getElementById('lenReadout');
-  const totalMm = computeTotalLengthMm();
-  const totalCm = totalMm / 10;
-  const tgtEl = document.getElementById('targetLenCm');
-  const tgtCm = parseFloat(tgtEl?.value || '0') || 0;
-  let txt = `Total length: ${totalCm.toFixed(1)} cm`;
-  if(tgtCm > 0){
-    const diff = totalCm - tgtCm;
-    const sign = diff > 0 ? '+' : '';
-    txt += ` (Target ${tgtCm.toFixed(1)} → ${sign}${diff.toFixed(1)} cm)`;
-  }
-  if(el) el.textContent = txt;
-  const summaryEl = document.getElementById('summaryLenVal');
-  if(summaryEl) summaryEl.textContent = `${totalCm.toFixed(1)} cm`;
-}
-
-function autofillQuantities(targetMm){
-  let current = computeTotalLengthMm();
-  if(current >= targetMm) return;
-  let deficit = targetMm - current;
-  const rowEls = Array.from(rowsBox.querySelectorAll('.row'));
-  const candidates = currentRows.map((row, i) => ({ i, per: Math.max(0.1, perRowLenMm[i] || 10) }))
-    .filter(c => rowEls[c.i]);
-  candidates.sort((a, b) => b.per - a.per);
-
-  while(deficit > 0 && candidates.length){
-    let progressed = false;
-    for(const c of candidates){
-      const rowData = currentRows[c.i];
-      const input = rowEls[c.i]?.querySelector('input[type="number"]');
-      if(!rowData || !input) continue;
-      const newQty = (rowData.qty || 0) + 1;
-      rowData.qty = newQty;
-      input.value = String(newQty);
-      deficit -= 2 * c.per;
-      progressed = true;
-      if(deficit <= 0) break;
-    }
-    if(!progressed) break;
-  }
-  currentRows = readRows();
-  updateLengthReadout();
-}
-
 let lastToken = 0;
 let lastMaterialSnapshot = null;
 let toastTimer = null;
@@ -1729,19 +1573,8 @@ async function loadScaleRotate(dir, filename, targetH, rotateDeg){
       if(inpPinBias){ inpPinBias.value = "0"; if(outPinBias) outPinBias.textContent = "0%"; }
       if(selMetal && METAL_PRESETS[0]) selMetal.value = METAL_PRESETS[0].id;
       if(inpWrist) inpWrist.value = BASE_WRIST_CM.toString();
-      const canvasSel = document.getElementById('canvasPreset');
-      if(canvasSel) canvasSel.value = '1080x320';
-      setCanvasSize(1080, 320);
-      LEN_PENDANT_MM = 50;
-      LEN_LOCK_MM = 5;
-      perRowLenMm = [];
+      setCanvasSize(1920, 520);
       currentRows = [];
-      const lenPendantInput = document.getElementById('lenPendantMm');
-      if(lenPendantInput) lenPendantInput.value = String(LEN_PENDANT_MM);
-      const lenLockInput = document.getElementById('lenLockMm');
-      if(lenLockInput) lenLockInput.value = String(LEN_LOCK_MM);
-      const targetInput = document.getElementById('targetLenCm');
-      if(targetInput) targetInput.value = '';
       zoomMode = 'fit';
       zoomScale = 1;
       zoomCenter = { x: 0, y: 0 };
@@ -2331,8 +2164,6 @@ for (let i = 0; i < rightSeq.length; i++) {
   }
   saveSession(true);
   currentRows = rows.map(r => ({...r}));
-  ensureRowLenInputs();
-  updateLengthReadout();
   if(zoomMode === 'fit'){
     requestAnimationFrame(() => fitViewport());
   }
@@ -2454,13 +2285,13 @@ const exporter = new STLExporter();
 const geometryCache = new Map();
 const metricsCache = new WeakMap();
 
-let renderer, scene, camera, controls;
-let currentObject = null;
-let activeMaterials = [];
-let wire = false;
-let loadToken = 0;
-let lastLayout = null;
-let stageHeight = typeof STAGE_H !== 'undefined' ? STAGE_H : 320;
+  let renderer, scene, camera, controls;
+  let currentObject = null;
+  let activeMaterials = [];
+  let wire = false;
+  let loadToken = 0;
+  let lastLayout = null;
+  let stageHeight = typeof STAGE_H !== 'undefined' ? STAGE_H : 520;
 let lastFitDistance = 12;
 const lights = {};
 


### PR DESCRIPTION
## Summary
- remove legacy length and canvas sizing controls from the builder sidebar
- move zoom controls into the preview header and default the stage to 1920×520
- update the preview canvas and 3D viewer defaults to match the new stage size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e13f4c1530832a835489c2394ae468