### PR TITLE
Add dual orb link configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -1020,7 +1020,11 @@ const PENDANTS = [
   "butterlfy 2.svg",
   "turtle 1.svg"
 ];
-const LINKS    = ["halo link.svg", "gold circle link.svg"];
+const LINKS    = [
+  "halo link.svg",
+  "gold circle link.svg",
+  "dual orb link.svg"
+];
 
 /* Locks (terminal, left end only) */
 const LOCKS = ["dolphin fish lock.svg"];
@@ -1060,6 +1064,14 @@ const LINK_PARTS = {
     over:  "gold circle link top.svg",
     targetH: 30,  // adjust if your circle looks too big/small
     rotate: 0     // set to 90 if your art is “standing up” sideways
+  },
+
+  "dual orb link.svg": {
+    base:  "dual orb link.svg",
+    under: "bottom half of the dual orb link.svg",
+    over:  "top half of the dual orb link.svg",
+    targetH: 36,
+    rotate: 0
   }
 };
 
@@ -1085,6 +1097,7 @@ const WEIGHTS = {
   "turtle 1.svg": 0.30,
   "halo link.svg": 0.10,
   "gold circle link.svg": 0.10,
+  "dual orb link.svg": 0.12,
   "dolphin fish lock.svg": 0.12,
   "__default_pendant": 0.30,
   "__default_link": 0.10


### PR DESCRIPTION
## Summary
- register the dual orb link in the link selector
- define dual orb link layer assets and sizing metadata
- include dual orb link weight for pricing calculations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e369d8cd48832a815692dc36a457df