### PR TITLE
Restore quick view modal and persist cart to checkout

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Checkout</title>
+<style>
+  body{font:16px/1.5 system-ui;margin:0;padding:24px;color:#222;background:#f6f6f6}
+  .wrap{max-width:900px;margin:0 auto;display:grid;gap:20px}
+  .card{background:#fff;border:1px solid #ddd;border-radius:12px;padding:18px}
+  h2{margin:0 0 10px}
+  table{width:100%;border-collapse:collapse}
+  th,td{padding:8px;border-bottom:1px solid #eee;text-align:left}
+  .grid{display:grid;gap:12px;grid-template-columns:1fr 1fr}
+  .grid label{display:grid;gap:6px}
+  button{padding:10px 14px;border-radius:10px;border:0;background:#6a4df5;color:#fff;font-weight:800;cursor:pointer}
+</style>
+<div class="wrap">
+  <div class="card">
+    <h2>1) Billing details</h2>
+    <form id="coForm" class="grid">
+      <label>First name<input name="firstName" required></label>
+      <label>Last name<input name="lastName" required></label>
+      <label>Country<input name="country" value="Lebanon" required></label>
+      <label>City<input name="city" required></label>
+      <label>Street address<input name="address" required></label>
+      <label>Phone<input name="phone" required></label>
+      <label style="grid-column:1/-1">Order notes<textarea name="notes" rows="3"></textarea></label>
+      <button style="grid-column:1/-1">Place order</button>
+    </form>
+  </div>
+
+  <div class="card">
+    <h2>2) Your order</h2>
+    <table id="coTable"><thead><tr><th>Product</th><th>Qty</th><th>Unit</th><th>Subtotal</th></tr></thead><tbody></tbody></table>
+    <p><strong>Total: </strong><span id="coTotal">$0</span></p>
+  </div>
+</div>
+
+<script>
+  const APP_URL = 'PASTE_YOUR_WEB_APP_URL_HERE';
+
+  const items = JSON.parse(localStorage.getItem('hcj-cart') || '[]');
+  const tbody = document.querySelector('#coTable tbody');
+  const totalEl = document.getElementById('coTotal');
+  let total = 0;
+  tbody.innerHTML = items.map(it => {
+    const sub = (it.price || 0) * (it.qty || 1);
+    total += sub;
+    return `<tr><td>${it.name}</td><td>${it.qty}</td><td>$${(it.price || 0).toLocaleString()}</td><td>$${sub.toLocaleString()}</td></tr>`;
+  }).join('');
+  totalEl.textContent = '$' + total.toLocaleString();
+
+  document.getElementById('coForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const fd = new FormData(e.target);
+    const payload = Object.fromEntries(fd.entries());
+    payload.items = items;
+    payload.total = total;
+    try{
+      const r = await fetch(APP_URL, { method: 'POST', body: JSON.stringify(payload) });
+      const ok = await r.json();
+      if(ok && ok.ok){
+        alert('Order placed! We will contact you soon.');
+        localStorage.removeItem('hcj-cart');
+        window.location.href = 'store.html';
+      }else{
+        alert('Could not place order. Please try again.');
+      }
+    }catch(err){
+      alert('Network error. Please try again.');
+    }
+  });
+</script>

--- a/store.html
+++ b/store.html
@@ -899,7 +899,22 @@
   if(checkoutBtn){
     checkoutBtn.addEventListener('click', () => {
       if(CART.size === 0) return;
-      window.location.href = '/checkout.html';
+      const payload = [];
+      CART.forEach((entry, sku) => {
+        payload.push({
+          sku,
+          name: entry?.product?.name || 'Item',
+          price: Number(entry?.product?.price || 0),
+          qty: Number(entry?.qty || 1),
+          kirat: entry?.product?.kirat || '',
+          weight: entry?.product?.weight || '',
+          img: entry?.img || ''
+        });
+      });
+      try {
+        localStorage.setItem('hcj-cart', JSON.stringify(payload));
+      } catch (e) {}
+      window.location.href = 'checkout.html';
     });
   }
 
@@ -1057,7 +1072,7 @@
       if(card.dataset.enhanced) return;
       card.dataset.enhanced = '1';
       const img = card.querySelector('.store-item__thumb .js-main');
-      if(img) attachMagnifier(img, {zoom:2.6, lens:140});
+      if(img) attachMagnifier(img, {zoom:3.0, lens:160});
     });
     filterByCategory(activeCat);
   }
@@ -1093,6 +1108,150 @@
   decorateCards();
   renderCartDrawer();
   showLivePricesFor(activeCat);
+})();
+</script>
+<script>
+(function(){
+  // ===== Quick View wiring =====
+  const out = document.getElementById('storeList');
+  const qv = document.getElementById('hcjQV');
+  const qvClose = qv?.querySelector('.hcj-qv__close');
+  const qvTitle = document.getElementById('hcjQVTitle');
+  const qvPrice = document.getElementById('hcjQVPrice');
+  const qvSpecs = document.getElementById('hcjQVSpecs');
+  const qvThumbs = document.getElementById('hcjQVThumbs');
+  const qvZoomBox = document.getElementById('hcjZoom');
+  const qvImg = document.getElementById('hcjZoomImg');
+  const qvLens = document.getElementById('hcjLens');
+  const addBtn = document.getElementById('hcjAddCartQV');
+  const waBtn = document.getElementById('hcjWA');
+
+  let current = null;
+  let magOn = false;
+  let magZoom = 2.6;
+
+  function money(n){
+    return Number(n || 0).toLocaleString();
+  }
+
+  function mountMagnifier(img){
+    function updateBG(){
+      qvLens.style.backgroundImage = `url(${img.src})`;
+      qvLens.style.backgroundSize = `${img.naturalWidth * magZoom}px ${img.naturalHeight * magZoom}px`;
+    }
+    function move(e){
+      if(!magOn) return;
+      const rect = img.getBoundingClientRect();
+      const x = (e.touches?.[0]?.clientX ?? e.clientX) - rect.left;
+      const y = (e.touches?.[0]?.clientY ?? e.clientY) - rect.top;
+      const bx = -((x * magZoom) - qvLens.offsetWidth / 2);
+      const by = -((y * magZoom) - qvLens.offsetHeight / 2);
+      qvLens.style.transform = `translate(${x - qvLens.offsetWidth / 2}px, ${y - qvLens.offsetHeight / 2}px)`;
+      qvLens.style.backgroundPosition = `${bx}px ${by}px`;
+    }
+    img.addEventListener('load', updateBG);
+    img.addEventListener('mousemove', move, { passive: true });
+    img.addEventListener('touchmove', move, { passive: true });
+    updateBG();
+  }
+
+  function setQVPhoto(src){
+    qvImg.src = src;
+    qvLens.style.backgroundImage = `url(${src})`;
+  }
+
+  function openQV(product){
+    current = product;
+    const photos = (window.driveImages && window.driveImages(product.photo)) || [];
+    qvTitle.textContent = product.name || 'Item';
+    qvPrice.textContent = money(product.price);
+    qvSpecs.innerHTML = [
+      product.kirat ? `<span>Karat: ${product.kirat}</span>` : '',
+      product.weight ? `<span>Weight: ${product.weight} g</span>` : '',
+      product.sku ? `<span>SKU: ${product.sku}</span>` : ''
+    ].filter(Boolean).join('');
+
+    qvThumbs.innerHTML = photos.map((u, i) => `
+      <img src="${u}" alt="thumb ${i + 1}" data-big="${u}" ${i === 0 ? 'style="outline:2px solid var(--gold)"' : ''}>
+    `).join('');
+    const first = photos[0] || 'icon/icon-512.png';
+    setQVPhoto(first);
+
+    qvThumbs.querySelectorAll('img').forEach(img => {
+      img.addEventListener('click', () => {
+        qvThumbs.querySelectorAll('img').forEach(x => x.style.outline = '');
+        img.style.outline = '2px solid var(--gold)';
+        setQVPhoto(img.dataset.big);
+      });
+    });
+
+    addBtn.onclick = () => {
+      const imgUrl = photos[0] || '';
+      if(window.HCJ_CART && typeof window.HCJ_CART.set === 'function'){
+        const sku = (product.sku || product.name || 'item').trim();
+        const existing = window.HCJ_CART.get(sku);
+        const qty = Math.min((product.stock || 1), (existing?.qty || 0) + 1);
+        window.HCJ_CART.set(sku, { product, qty, img: imgUrl });
+        document.dispatchEvent(new CustomEvent('hcj:cart-updated'));
+      }
+    };
+
+    const msg = encodeURIComponent(`${product.name} (${product.sku || 'no sku'}) - $${money(product.price)}`);
+    waBtn.href = `https://wa.me/?text=${msg}`;
+
+    magOn = false;
+    qvLens.style.display = 'none';
+
+    qv.setAttribute('aria-hidden', 'false');
+    mountMagnifier(qvImg);
+  }
+
+  function closeQV(){
+    qv.setAttribute('aria-hidden', 'true');
+    current = null;
+  }
+
+  qvClose?.addEventListener('click', closeQV);
+  qv?.addEventListener('click', e => { if(e.target === qv) closeQV(); });
+  document.addEventListener('keydown', e => { if(e.key === 'Escape') closeQV(); });
+
+  const controls = document.createElement('div');
+  controls.style = 'display:flex; gap:10px; align-items:center; margin-top:8px;';
+  controls.innerHTML = `
+    <label style="display:inline-flex;gap:6px;align-items:center;cursor:pointer;">
+      <input id="hcjMagToggle" type="checkbox"> Magnifier
+    </label>
+    <label style="display:inline-flex;gap:6px;align-items:center;">
+      Zoom <input id="hcjMagZoom" type="range" min="1.5" max="4" step="0.1" value="2.6" style="width:140px">
+    </label>
+  `;
+  qvZoomBox?.after(controls);
+  const toggle = controls.querySelector('#hcjMagToggle');
+  const zoom = controls.querySelector('#hcjMagZoom');
+  toggle?.addEventListener('change', () => {
+    magOn = toggle.checked;
+    qvLens.style.display = magOn ? 'block' : 'none';
+  });
+  zoom?.addEventListener('input', () => {
+    magZoom = Number(zoom.value);
+    qvLens.style.backgroundSize = `${qvImg.naturalWidth * magZoom}px ${qvImg.naturalHeight * magZoom}px`;
+  });
+
+  out?.addEventListener('click', (e) => {
+    const btn = e.target.closest('.mini-cart');
+    if(btn) return;
+    const card = e.target.closest('.product-card');
+    if(!card) return;
+    const sku = card.dataset.sku || '';
+    const list = window.PRODUCTS || [];
+    const title = (card.querySelector('.store-item__title')?.textContent || '').trim().toLowerCase();
+    const product = list.find(p => (p.sku || '') === sku) || list.find(p => String(p.name || '').trim().toLowerCase() === title);
+    if(product){
+      openQV(product);
+    }
+  }, true);
+
+  document.addEventListener('hcj:cart-updated', () => {});
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- wire the store quick view modal to product cards, add magnifier controls, and keep the mini-cart lens responsive
- persist cart contents before navigating to checkout so the cart survives the transition
- add a checkout page that renders saved cart items and posts orders to the configured Apps Script endpoint

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e36cf2cd40832ab8556797f883a366