### PR TITLE
Add new pendant options with hidden pin support

### DIFF
--- a/index.html
+++ b/index.html
@@ -1016,8 +1016,15 @@ currentTheme = applyTheme(currentTheme);
 /* Exact asset names */
 const PENDANTS = [
   "Infinity Knot 1.svg",
+  "infinity knot 2.svg",
+  "infinity knot 3.svg",
+  "infinity knot 4.svg",
   "butterlfy 1.svg",
   "butterlfy 2.svg",
+  "flower 1.svg",
+  "flower 2.svg",
+  "flower 3.svg",
+  "flower 4.svg",
   "turtle 1.svg"
 ];
 const LINKS    = [
@@ -1092,8 +1099,15 @@ const PENDANT_MASK_ID = "pendantCutMask";
 /* Placeholder weights */
 const WEIGHTS = {
   "Infinity Knot 1.svg": 0.32,
+  "infinity knot 2.svg": 0.32,
+  "infinity knot 3.svg": 0.32,
+  "infinity knot 4.svg": 0.32,
   "butterlfy 1.svg": 0.30,
   "butterlfy 2.svg": 0.30,
+  "flower 1.svg": 0.30,
+  "flower 2.svg": 0.30,
+  "flower 3.svg": 0.30,
+  "flower 4.svg": 0.30,
   "turtle 1.svg": 0.30,
   "halo link.svg": 0.10,
   "gold circle link.svg": 0.10,


### PR DESCRIPTION
## Summary
- register the newly provided pendant SVGs in the configurator so they can be selected
- assign placeholder weights for each new pendant to support material estimates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e3720bf3bc832ab5bf2bb66766bd1e