### PR TITLE
Fix quick view magnifier activation

### DIFF
--- a/store.html
+++ b/store.html
@@ -1440,14 +1440,16 @@
     if(qvLens){
       if(magOn){
         // Show lens immediately and center it
-        const rect = qvImg.getBoundingClientRect();
-        const cx = rect.width / 2; const cy = rect.height / 2;
-        const bx = -((cx * magZoom) - qvLens.offsetWidth / 2);
-        const by = -((cy * magZoom) - qvLens.offsetHeight / 2);
-        qvLens.style.transform = `translate(${cx - qvLens.offsetWidth / 2}px, ${cy - qvLens.offsetHeight / 2}px)`;
-        qvLens.style.backgroundPosition = `${bx}px ${by}px`;
         qvLens.style.display = 'block';
         updateLensBackground();
+        const rect = qvImg.getBoundingClientRect();
+        const lensW = qvLens.offsetWidth || 0;
+        const lensH = qvLens.offsetHeight || 0;
+        const cx = rect.width / 2; const cy = rect.height / 2;
+        const bx = -((cx * magZoom) - lensW / 2);
+        const by = -((cy * magZoom) - lensH / 2);
+        qvLens.style.transform = `translate(${cx - lensW / 2}px, ${cy - lensH / 2}px)`;
+        qvLens.style.backgroundPosition = `${bx}px ${by}px`;
       }else{
         qvLens.style.display = 'none';
       }


### PR DESCRIPTION
## Summary
- ensure the quick-view magnifier lens is displayed before measuring its size
- center the lens using its measured dimensions so the toggle and zoom controls work

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_b_68e3881d6e94832aabf277b59e4ab233