### PR TITLE
Update WhatsApp cart link with phone number

### DIFF
--- a/store.html
+++ b/store.html
@@ -1386,7 +1386,7 @@
 
     const msg = encodeURIComponent(`${name} (${product?.sku || 'no sku'}) - $${money(product?.price)}`);
     if(waBtn){
-      waBtn.href = `https://wa.me/?text=${msg}`;
+      waBtn.href = `https://wa.me/393481651384?text=${msg}`;
     }
 
     magOn = false;


### PR DESCRIPTION
## Summary
- add the business WhatsApp number to the quick view cart link so it uses +393481651384 when sharing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e38976e7d8832a8c6fc5f82887dff4