### PR TITLE
Switch try-on modal to photo uploads

### DIFF
--- a/store.html
+++ b/store.html
@@ -370,7 +370,8 @@
     </header>
 
     <div class="tryon-stage">
-      <video id="tryon-video" playsinline autoplay muted></video>
+      <!-- Background photo (user-taken or uploaded) -->
+      <img id="bg-photo" class="uploaded-photo" alt="">
       <div id="ring-overlay" class="ring-overlay" draggable="false">
         <img id="ring-image" alt="Ring overlay" />
       </div>
@@ -383,10 +384,17 @@
       <label>Rotate
         <input id="rotateRange" type="range" min="-90" max="90" step="1" value="0">
       </label>
-      <button id="flipCamBtn" type="button">Flip camera</button>
+
+      <!-- Take a new photo (opens camera on mobile) -->
+      <label class="upload-fallback">
+        <input id="photoCapture" type="file" accept="image/*" capture="environment" hidden>
+        <span>Take photo</span>
+      </label>
+
+      <!-- Or upload from gallery/files -->
       <label class="upload-fallback">
         <input id="photoUpload" type="file" accept="image/*" hidden>
-        <span>Upload photo instead</span>
+        <span>Upload photo</span>
       </label>
     </div>
   </div>
@@ -1565,242 +1573,138 @@
   const modal = document.getElementById('tryon-modal');
   if(!modal) return;
 
-  const closeBtn = document.getElementById('tryon-close');
-  const video = document.getElementById('tryon-video');
-  const ringOverlay = document.getElementById('ring-overlay');
-  const ringImage = document.getElementById('ring-image');
-  const sizeRange = document.getElementById('sizeRange');
-  const rotateRange = document.getElementById('rotateRange');
-  const flipCamBtn = document.getElementById('flipCamBtn');
-  const photoUpload = document.getElementById('photoUpload');
-  const stage = modal.querySelector('.tryon-stage');
+  const closeBtn     = document.getElementById('tryon-close');
+  const bgPhoto      = document.getElementById('bg-photo');
+  const ringOverlay  = document.getElementById('ring-overlay');
+  const ringImage    = document.getElementById('ring-image');
+  const sizeRange    = document.getElementById('sizeRange');
+  const rotateRange  = document.getElementById('rotateRange');
+  const photoUpload  = document.getElementById('photoUpload');
+  const photoCapture = document.getElementById('photoCapture');
 
-  let currentStream = null;
-  let useFront = false;
   let uploadedUrl = null;
-  const base = { x: 0, y: 0, scale: 1, rot: 0 };
-  const drag = { active: false, startX: 0, startY: 0, startTx: 0, startTy: 0, pointerId: null };
+  const base = { x:0, y:0, scale:1, rot:0 };
+  const drag = { on:false, sx:0, sy:0, tx:0, ty:0, id:null };
 
-  function clearUploadedBackground(){
-    const img = stage?.querySelector('img.uploaded-photo');
-    if(img){
-      if(uploadedUrl){
-        URL.revokeObjectURL(uploadedUrl);
-        uploadedUrl = null;
-      }
-      img.remove();
-    }
+  /* -------- Drive link -> safe image URL (lh3 endpoint) -------- */
+  function driveToImg(url){
+    if(!url) return '';
+    try{
+      const u = new URL(String(url).trim());
+      const m1 = u.pathname.match(/\/d\/([a-zA-Z0-9_-]+)/);
+      const m2 = u.search.match(/[?&]id=([a-zA-Z0-9_-]+)/);
+      const id = (m1 && m1[1]) || (m2 && m2[1]);
+      return id ? `https://lh3.googleusercontent.com/d/${id}=w1600` : url;
+    }catch{ return url; }
   }
 
-  function stopCamera(){
-    if(currentStream){
-      currentStream.getTracks().forEach(track => track.stop());
-      currentStream = null;
-    }
-    if(video){
-      video.srcObject = null;
-      video.pause?.();
-    }
-  }
-
-  async function startCamera(){
-    stopCamera();
-    if(!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)){
-      if(photoUpload) photoUpload.click();
-      return;
-    }
-    const constraints = {
-      video: {
-        facingMode: useFront ? 'user' : { ideal: 'environment' },
-        width: { ideal: 1280 },
-        height: { ideal: 1920 }
-      },
-      audio: false
-    };
-    try {
-      currentStream = await navigator.mediaDevices.getUserMedia(constraints);
-      if(video){
-        video.srcObject = currentStream;
-        await video.play().catch(() => {});
-      }
-      clearUploadedBackground();
-    } catch (err) {
-      console.warn('Camera error', err);
-      if(photoUpload) photoUpload.click();
-    }
-  }
-
-  function applyTransform(){
-    if(!ringOverlay) return;
-    ringOverlay.style.transform = `translate(calc(-50% + ${base.x}px), calc(-50% + ${base.y}px)) scale(${base.scale}) rotate(${base.rot}deg)`;
-  }
-
+  /* -------- Open / Close -------- */
   function resetTransform(){
-    base.x = 0;
-    base.y = 0;
-    base.scale = 1;
-    base.rot = 0;
-    if(sizeRange) sizeRange.value = String(base.scale);
-    if(rotateRange) rotateRange.value = String(base.rot);
+    base.x = 0; base.y = 0; base.scale = 1; base.rot = 0;
+    sizeRange && (sizeRange.value = '1');
+    rotateRange && (rotateRange.value = '0');
     applyTransform();
   }
-
+  function applyTransform(){
+    ringOverlay.style.transform =
+      `translate(calc(-50% + ${base.x}px), calc(-50% + ${base.y}px)) scale(${base.scale}) rotate(${base.rot}deg)`;
+  }
+  function clearBg(){
+    if(uploadedUrl){ URL.revokeObjectURL(uploadedUrl); uploadedUrl = null; }
+    if(bgPhoto){ bgPhoto.removeAttribute('src'); }
+  }
   function openTryOn(ringUrl){
-    if(!modal) return;
-    if(ringImage){
-      ringImage.crossOrigin = 'anonymous';
-      ringImage.src = ringUrl || '';
-    }
     resetTransform();
-    clearUploadedBackground();
-    if(photoUpload) photoUpload.value = '';
+    clearBg();
+    ringImage.crossOrigin = 'anonymous';
+    ringImage.src = driveToImg(ringUrl || '');
     modal.hidden = false;
     document.body.style.overflow = 'hidden';
-    startCamera();
   }
-
   function closeTryOn(){
     modal.hidden = true;
     document.body.style.overflow = '';
-    stopCamera();
-    clearUploadedBackground();
+    clearBg();
   }
 
-  function attachTryOnButton(cardEl, product){
-    if(!cardEl) return;
-    const btn = cardEl.querySelector('.try-on-btn');
+  /* -------- Drag / wheel controls -------- */
+  ringOverlay.addEventListener('pointerdown', (e)=>{
+    drag.on = true; drag.id = e.pointerId;
+    drag.sx = e.clientX; drag.sy = e.clientY;
+    drag.tx = base.x; drag.ty = base.y;
+    ringOverlay.setPointerCapture?.(e.pointerId);
+  });
+  ringOverlay.addEventListener('pointermove', (e)=>{
+    if(!drag.on) return;
+    base.x = drag.tx + (e.clientX - drag.sx);
+    base.y = drag.ty + (e.clientY - drag.sy);
+    applyTransform();
+  });
+  function endDrag(){ drag.on = false; drag.id = null; }
+  ringOverlay.addEventListener('pointerup', endDrag);
+  ringOverlay.addEventListener('pointercancel', endDrag);
+  ringOverlay.addEventListener('wheel', (e)=>{
+    e.preventDefault();
+    const f = e.deltaY < 0 ? 1.05 : 0.95;
+    base.scale = Math.min(3, Math.max(0.2, base.scale * f));
+    sizeRange.value = String(base.scale);
+    applyTransform();
+  }, {passive:false});
+
+  sizeRange.addEventListener('input', e=>{
+    base.scale = Math.min(3, Math.max(0.2, parseFloat(e.target.value)||1));
+    applyTransform();
+  });
+  rotateRange.addEventListener('input', e=>{
+    base.rot = Math.max(-180, Math.min(180, parseFloat(e.target.value)||0));
+    applyTransform();
+  });
+
+  /* -------- Capture / Upload -------- */
+  function setBgFromFile(file){
+    if(!file) return;
+    clearBg();
+    uploadedUrl = URL.createObjectURL(file);
+    bgPhoto.src = uploadedUrl;
+  }
+  photoCapture?.addEventListener('change', ()=> setBgFromFile(photoCapture.files?.[0]));
+  photoUpload?.addEventListener('change', ()=> setBgFromFile(photoUpload.files?.[0]));
+
+  /* -------- Buttons on cards -------- */
+  function attachTryOnButton(card, product){
+    const btn = card.querySelector('.try-on-btn');
     if(!btn) return;
-    const url = product?.tryOnUrl ? String(product.tryOnUrl) : '';
-    if(url){
-      btn.dataset.tryon = url;
-      btn.hidden = false;
-    }else{
-      btn.dataset.tryon = '';
-      btn.hidden = true;
-    }
+    const url = product?.tryOnUrl ? driveToImg(product.tryOnUrl) : '';
+    if(url){ btn.dataset.tryon = url; btn.hidden = false; }
+    else   { btn.dataset.tryon = '';  btn.hidden = true;  }
   }
-
-  function syncButtonsWithProducts(products){
-    const list = Array.isArray(products) ? products : (Array.isArray(window.PRODUCTS) ? window.PRODUCTS : []);
-    list.forEach((product, index) => {
-      const card = document.querySelector(`.product-card[data-idx="${index}"]`);
-      if(card) attachTryOnButton(card, product);
+  function syncButtons(products){
+    (products || window.PRODUCTS || []).forEach((p,i)=>{
+      const card = document.querySelector(`.product-card[data-idx="${i}"]`);
+      if(card) attachTryOnButton(card, p);
     });
   }
-
-  function wireAllTryOnButtons(root=document){
-    root.querySelectorAll('.try-on-btn').forEach(btn => {
-      if(btn.dataset.tryonWired === '1') return;
-      btn.dataset.tryonWired = '1';
-      btn.addEventListener('click', () => {
-        const url = btn.dataset.tryon;
-        if(url) openTryOn(url);
+  function wireButtons(root=document){
+    root.querySelectorAll('.try-on-btn').forEach(btn=>{
+      if(btn.dataset.wired === '1') return;
+      btn.dataset.wired = '1';
+      btn.addEventListener('click', ()=>{
+        const url = btn.dataset.tryon; if(url) openTryOn(url);
       });
     });
   }
 
-  function onPointerDown(e){
-    drag.active = true;
-    drag.startX = e.clientX;
-    drag.startY = e.clientY;
-    drag.startTx = base.x;
-    drag.startTy = base.y;
-    drag.pointerId = e.pointerId;
-    ringOverlay?.setPointerCapture?.(e.pointerId);
-  }
-
-  function onPointerMove(e){
-    if(!drag.active) return;
-    const dx = e.clientX - drag.startX;
-    const dy = e.clientY - drag.startY;
-    base.x = drag.startTx + dx;
-    base.y = drag.startTy + dy;
-    applyTransform();
-  }
-
-  function endPointer(e){
-    if(drag.pointerId != null){
-      ringOverlay?.releasePointerCapture?.(drag.pointerId);
-    }
-    drag.active = false;
-    drag.pointerId = null;
-  }
-
-  function onWheel(e){
-    e.preventDefault();
-    const factor = e.deltaY < 0 ? 1.05 : 0.95;
-    const next = Math.min(3, Math.max(0.2, base.scale * factor));
-    base.scale = next;
-    if(sizeRange) sizeRange.value = String(next);
-    applyTransform();
-  }
-
   closeBtn?.addEventListener('click', closeTryOn);
-  modal.addEventListener('click', evt => {
-    if(evt.target === modal) closeTryOn();
-  });
-  document.addEventListener('keydown', evt => {
-    if(evt.key === 'Escape' && !modal.hidden) closeTryOn();
-  });
+  modal.addEventListener('click', e=>{ if(e.target === modal) closeTryOn(); });
+  document.addEventListener('keydown', e=>{ if(e.key === 'Escape' && !modal.hidden) closeTryOn(); });
 
-  flipCamBtn?.addEventListener('click', () => {
-    useFront = !useFront;
-    startCamera();
+  document.addEventListener('hcj:products-rendered', e=>{
+    syncButtons(e.detail?.products);
+    wireButtons();
   });
-
-  sizeRange?.addEventListener('input', e => {
-    const value = parseFloat(e.target.value);
-    if(Number.isFinite(value)){
-      base.scale = Math.min(3, Math.max(0.2, value));
-      applyTransform();
-    }
-  });
-
-  rotateRange?.addEventListener('input', e => {
-    const value = parseFloat(e.target.value);
-    if(Number.isFinite(value)){
-      base.rot = Math.max(-180, Math.min(180, value));
-      applyTransform();
-    }
-  });
-
-  ringOverlay?.addEventListener('pointerdown', onPointerDown);
-  ringOverlay?.addEventListener('pointermove', onPointerMove);
-  ringOverlay?.addEventListener('pointerup', endPointer);
-  ringOverlay?.addEventListener('pointercancel', endPointer);
-  ringOverlay?.addEventListener('wheel', onWheel, { passive: false });
-
-  photoUpload?.addEventListener('change', () => {
-    const file = photoUpload.files?.[0];
-    if(!file) return;
-    stopCamera();
-    if(uploadedUrl) URL.revokeObjectURL(uploadedUrl);
-    uploadedUrl = URL.createObjectURL(file);
-    let img = stage?.querySelector('img.uploaded-photo');
-    if(!img && stage){
-      img = document.createElement('img');
-      img.className = 'uploaded-photo';
-      stage.prepend(img);
-    }
-    if(img) img.src = uploadedUrl;
-  });
-
-  document.addEventListener('hcj:products-rendered', event => {
-    syncButtonsWithProducts(event.detail?.products);
-    wireAllTryOnButtons();
-  });
-
   if(document.readyState === 'loading'){
-    document.addEventListener('DOMContentLoaded', () => {
-      syncButtonsWithProducts(window.PRODUCTS);
-      wireAllTryOnButtons();
-    });
-  }else{
-    syncButtonsWithProducts(window.PRODUCTS);
-    wireAllTryOnButtons();
-  }
-
-  window.addEventListener('beforeunload', stopCamera);
+    document.addEventListener('DOMContentLoaded', ()=>{ syncButtons(window.PRODUCTS); wireButtons(); });
+  }else{ syncButtons(window.PRODUCTS); wireButtons(); }
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- replace the try-on modal stage with a still-photo background container
- update modal controls to support taking or uploading a photo instead of flipping the camera
- rewrite the try-on script to drop getUserMedia, add drive link conversion, and handle photo capture/upload transforms

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e3b4e6abc8832abc864cc73f5e2d9e