### PR TITLE
Add Arrow and Eclipse link options to bracelet builder

### DIFF
--- a/index.html
+++ b/index.html
@@ -1030,7 +1030,9 @@ const PENDANTS = [
 const LINKS    = [
   "halo link.svg",
   "gold circle link.svg",
-  "dual orb link.svg"
+  "dual orb link.svg",
+  "Arrow Link.svg",
+  "Eclipse Link.svg"
 ];
 
 /* Locks (terminal, left end only) */
@@ -1079,6 +1081,22 @@ const LINK_PARTS = {
     over:  "top half of the dual orb link.svg",
     targetH: 36,
     rotate: 0
+  },
+
+  "Arrow Link.svg": {
+    base:  "Arrow Link.svg",
+    under: "bottom half of Arrow Link.svg",
+    over:  "top half of Arrow Link.svg",
+    targetH: 34,
+    rotate: 0
+  },
+
+  "Eclipse Link.svg": {
+    base:  "Eclipse Link.svg",
+    under: "bottom half of Eclipse Link.svg",
+    over:  "top half of Eclipse Link.svg",
+    targetH: 34,
+    rotate: 0
   }
 };
 
@@ -1112,6 +1130,8 @@ const WEIGHTS = {
   "halo link.svg": 0.10,
   "gold circle link.svg": 0.10,
   "dual orb link.svg": 0.12,
+  "Arrow Link.svg": 0.10,
+  "Eclipse Link.svg": 0.10,
   "dolphin fish lock.svg": 0.12,
   "__default_pendant": 0.30,
   "__default_link": 0.10


### PR DESCRIPTION
## Summary
- add Arrow Link and Eclipse Link assets to the builder's link selector with split art definitions so the hidden pin overlays continue to align
- assign default weights for the new link variants to keep material estimates working

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e535e97494832ab228f1965d8b98db