### PR TITLE
Fix live price pills duplication and enhance quick view zoom

### DIFF
--- a/store.html
+++ b/store.html
@@ -160,6 +160,26 @@
     color:var(--ink);border-radius:999px;padding:10px 16px;font-weight:700;cursor:pointer}
   .live-badges{display:flex;gap:10px;padding:10px 0;flex-wrap:wrap}
   .pill{padding:6px 10px;border-radius:999px;background:var(--control-bg);border:1px solid var(--border-soft);font-weight:700}
+  /* make live price pills behave like buttons and show selected state */
+  #liveBadges button.pill{ cursor:pointer }
+  #liveBadges .pill.active{
+    border-color: var(--gold);
+    color: var(--gold);
+    box-shadow: 0 2px 12px rgba(0,0,0,.15);
+  }
+
+  /* large zoom box shown when Magnifier is on (desktop/tablet) */
+  .hcj-zoombox{
+    border:1px solid var(--border-soft);
+    border-radius:14px;
+    background:#000;
+    background-repeat:no-repeat;
+    background-position:center;
+    background-size:220%;
+    display:none;
+    min-height:280px;
+  }
+  @media (max-width:900px){ .hcj-zoombox{ display:none !important; } }
   .cat-meta{margin-top:8px;font-size:.95rem;color:var(--muted)}
   .product-card{position:relative}
   .product-card .mini-cart{position:absolute;left:12px;bottom:12px;width:42px;height:42px;border-radius:999px;
@@ -631,21 +651,33 @@
     async function tick(){
       try{
         const oz = await getSpotFast();
-        // Fill/override price for every product based on kirat & weight
+
+        // --- NEW: keep a single global snapshot with ounce, grams & timestamp
+        window.__HCJ_SPOT = {
+          oz,
+          g18: Math.round(perGramForKirat(oz,'18',10)),
+          g21: Math.round(perGramForKirat(oz,'21',10)),
+          g22: Math.round(perGramForKirat(oz,'22',10)),
+          g24: Math.round(perGramForKirat(oz,'24',10)),
+          updatedAt: Date.now()
+        };
+        window.dispatchEvent(new CustomEvent('hcj:spot-update', { detail: window.__HCJ_SPOT }));
+
+        // Recompute each product price from kirat/weight/fee
         products.forEach(p => {
           const calc = computeItemPriceUSD(oz, p);
-          if (isFinite(calc)) p.price = Math.round(calc); // round how you like
+          if (isFinite(calc)) p.price = Math.round(calc);
         });
-        // If first time, render the grid; otherwise, update prices in-place
+
+        // Render/update
         if(!document.querySelector('.product-card')){
           render(products);
         }else if(typeof updatePricesInPlace === 'function'){
           updatePricesInPlace(products);
-          // Notify other modules (filters/sorting) that prices changed
           document.dispatchEvent(new CustomEvent('hcj:prices-updated', { detail: { products } }));
         }
-      }catch(e){
-        // On failure just keep whatever is rendered now
+      }catch(_){
+        /* keep current UI if a fetch fails */
       }
     }
     // run now + schedule
@@ -743,8 +775,10 @@
       const safeSkuAttr = escapeHtml(p.sku || "");
       const stockVal = Number.isFinite(p.stock) ? Math.max(0, Math.floor(p.stock)) : '';
       const stockAttr = stockVal === '' ? '' : String(stockVal);
+      const kNum = (p.kirat || '').toString().match(/\d{2}/)?.[0] || '';
+      const kAttr = kNum ? ` data-k="${kNum}"` : '';
       return `
-        <article class="store-item card product-card" data-idx="${i}" data-cat="${safeCat}" data-sku="${safeSkuAttr}" data-price="${priceNum}"${stockAttr!==''?` data-stock="${stockAttr}"`:''}>
+        <article class="store-item card product-card" data-idx="${i}" data-cat="${safeCat}" data-sku="${safeSkuAttr}" data-price="${priceNum}"${stockAttr!==''?` data-stock="${stockAttr}"`:''}${kAttr}>
           <figure class="store-item__thumb">
             ${main ? `<img class="js-main" src="${escapeHtml(main)}" alt="${safeTitle || 'Bracelet photo'}" loading="lazy">`
                    : `<div class="store-item__placeholder" aria-hidden="true"></div>`}
@@ -988,6 +1022,29 @@
   const escape = value => String(value ?? '').replace(/[&<>"']/g, ch => ESC[ch] || ch);
 
   let activeCat = 'all';
+  let activeKarat = null;            // null = all
+  let LIVE_TICKET = 0;               // prevents duplicate renders
+
+  function setActiveKarat(k){
+    activeKarat = (k==null ? null : Number(k));
+    // visual state on the buttons
+    liveBadges?.querySelectorAll('button[data-k]').forEach(b=>{
+      const on = Number(b.dataset.k) === activeKarat;
+      b.classList.toggle('active', on);
+      b.setAttribute('aria-pressed', on ? 'true' : 'false');
+    });
+    const resetBtn = liveBadges?.querySelector('button[data-reset]');
+    if(resetBtn){
+      const on = activeKarat == null;
+      resetBtn.classList.toggle('active', on);
+      resetBtn.setAttribute('aria-pressed', on ? 'true' : 'false');
+    }
+    // re-apply all filters (category + price + karat)
+    if(typeof window.HCJ_APPLY_FILTERS === 'function') window.HCJ_APPLY_FILTERS();
+  }
+
+  function pad(n){ return String(n).padStart(2,'0'); }
+
   const CART = window.HCJ_CART instanceof Map ? window.HCJ_CART : new Map();
   // Use a stable per-piece key independent of SKU
   function keyForProduct(p){
@@ -1034,7 +1091,7 @@
     });
     // Apply combined filters (category + price)
     if(typeof window.HCJ_APPLY_FILTERS === 'function') window.HCJ_APPLY_FILTERS(); else filterByCategory(activeCat);
-    showLivePricesFor(activeCat);
+    showLivePricesFor();
   }
 
 
@@ -1096,7 +1153,8 @@
       const price = parseFloat(card.dataset.price || '0');
       const inCat = (activeCat === 'all') || (card.dataset.cat === activeCat);
       const inPrice = (min==null || price >= min) && (max==null || price <= max);
-      const show = inCat && inPrice;
+      const inKarat = (activeKarat==null) || (Number(card.dataset.k || 0) === activeKarat);
+      const show = inCat && inPrice && inKarat;
       card.style.display = show ? '' : 'none';
     });
     // sort visible ones if needed
@@ -1135,26 +1193,74 @@
     catMeta.textContent = count ? `${label} • ${piecesText}${weightText}` : `${label} • No items`;
   }
 
-  async function showLivePricesFor(catId){
+  async function showLivePricesFor(){
     if(!liveBadges) return;
+    const ticket = ++LIVE_TICKET;     // cancel older in-flight calls
     liveBadges.textContent = '';
-    const getSpot = typeof HCJ.getSpotOz === 'function' ? HCJ.getSpotOz : null;
-    const perGram = typeof HCJ.perGramForKirat === 'function' ? HCJ.perGramForKirat : null;
-    if(!getSpot || !perGram) return;
-    try{
-      const oz = await getSpot();
-      ['18','21','22','24'].forEach(k => {
-        const price = perGram(oz, k, 10);
-        if(Number.isFinite(price)){
-          const pill = document.createElement('span');
-          pill.className = 'pill';
-          pill.textContent = `${k}K ${Math.round(price)}`;
-          liveBadges.appendChild(pill);
-        }
-      });
-    }catch(_){
-      /* ignore transient network errors */
+
+    // Caption (what these numbers mean)
+    const caption = document.createElement('div');
+    caption.className = 'cat-meta';
+    caption.textContent = 'Price per gram (includes a small making fee). Tap a karat to filter.';
+    liveBadges.appendChild(caption);
+
+    // Prefer the latest global snapshot prepared by startSpotRefresh()
+    let spot = window.__HCJ_SPOT;
+    if(!spot || !Number.isFinite(spot.oz)){
+      const getSpot = window.HCJ?.getSpotOz;
+      const perGram = window.HCJ?.perGramForKirat;
+      if(!getSpot || !perGram) return;
+      try{
+        const oz = await getSpot();
+        if(ticket !== LIVE_TICKET) return; // a newer call already won
+        spot = {
+          oz,
+          g18: Math.round(perGram(oz,'18',10)),
+          g21: Math.round(perGram(oz,'21',10)),
+          g22: Math.round(perGram(oz,'22',10)),
+          g24: Math.round(perGram(oz,'24',10)),
+          updatedAt: Date.now()
+        };
+        window.__HCJ_SPOT = spot;
+      }catch(_){ return; }
     }
+
+    // XAU/oz and last update
+    const ozPill = document.createElement('span');
+    ozPill.className='pill';
+    ozPill.textContent = `XAU/oz $${Math.round(spot.oz).toLocaleString()}`;
+    const ts = new Date(spot.updatedAt || Date.now());
+    const tsPill = document.createElement('span');
+    tsPill.className='pill';
+    tsPill.textContent = `Last update: ${pad(ts.getDate())}/${pad(ts.getMonth()+1)}/${ts.getFullYear()}, ${pad(ts.getHours())}:${pad(ts.getMinutes())}:${pad(ts.getSeconds())}`;
+    liveBadges.append(ozPill, tsPill);
+
+    // Clickable karat buttons
+    [['18',spot.g18], ['21',spot.g21], ['22',spot.g22], ['24',spot.g24]].forEach(([k,price])=>{
+      if(Number.isFinite(price)){
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'pill';
+        btn.dataset.k = k;
+        btn.textContent = `${k}K ${Number(price).toLocaleString()}`;
+        btn.setAttribute('aria-pressed','false');
+        btn.addEventListener('click', ()=> setActiveKarat(Number(k)));
+        liveBadges.appendChild(btn);
+      }
+    });
+
+    // Reset button
+    const reset = document.createElement('button');
+    reset.type = 'button';
+    reset.className = 'pill';
+    reset.textContent = 'All karats';
+    reset.dataset.reset = '1';
+    reset.setAttribute('aria-pressed','false');
+    reset.addEventListener('click', ()=> setActiveKarat(null));
+    liveBadges.appendChild(reset);
+
+    // Ensure current selection is reflected on buttons
+    setActiveKarat(activeKarat);
   }
 
   function openCart(){ cartDrawer?.setAttribute('aria-hidden','false'); }
@@ -1379,7 +1485,8 @@
   setActiveCategory(activeCat);
   decorateCards();
   renderCartDrawer();
-  showLivePricesFor(activeCat);
+  showLivePricesFor();
+  window.addEventListener('hcj:spot-update', () => showLivePricesFor());
   if(typeof window.HCJ_APPLY_FILTERS === 'function') window.HCJ_APPLY_FILTERS();
 })();
 </script>
@@ -1396,6 +1503,11 @@
   const zoomWrap = document.getElementById('hcjZoom');
   const qvImg = document.getElementById('hcjZoomImg');
   const qvLens = document.getElementById('hcjLens');
+  // A big zoom viewport (like your sample site)
+  const qvZoomBox = document.createElement('div');
+  qvZoomBox.id = 'hcjZoomBox';
+  qvZoomBox.className = 'hcj-zoombox';
+  zoomWrap?.after(qvZoomBox);
   const addBtn = document.getElementById('hcjAddCartQV');
   const waBtn = document.getElementById('hcjWA');
 
@@ -1408,32 +1520,55 @@
   }
 
   function updateLensBackground(){
-    if(!qvLens || !qvImg) return;
-    const w = qvImg.naturalWidth;
-    const h = qvImg.naturalHeight;
+    if(!qvImg) return;
+    const w = qvImg.naturalWidth, h = qvImg.naturalHeight;
     if(w && h){
-      qvLens.style.backgroundImage = `url(${qvImg.src})`;
-      qvLens.style.backgroundSize = `${w * magZoom}px ${h * magZoom}px`;
+      const size = `${w * magZoom}px ${h * magZoom}px`;
+      if(qvLens){
+        qvLens.style.backgroundImage = `url(${qvImg.src})`;
+        qvLens.style.backgroundSize = size;
+      }
+      if(qvZoomBox){
+        qvZoomBox.style.backgroundImage = `url(${qvImg.src})`;
+        qvZoomBox.style.backgroundSize = size;
+      }
     }
   }
 
   function enableQVZoom(){
-    if(!zoomWrap || !qvLens || !qvImg) return;
+    if(!zoomWrap || !qvImg) return;
     disableQVZoom();
-    qvLens.style.display = 'none';
+    if(qvLens) qvLens.style.display = 'none';
+    if(qvZoomBox) qvZoomBox.style.display = 'none';
     const onMove = (e) => {
       if(!magOn) return;
       const point = e.touches?.[0] ?? e;
       const rect = zoomWrap.getBoundingClientRect();
       const x = Math.max(0, Math.min(point.clientX - rect.left, rect.width));
       const y = Math.max(0, Math.min(point.clientY - rect.top, rect.height));
-      const bx = -((x * magZoom) - qvLens.offsetWidth / 2);
-      const by = -((y * magZoom) - qvLens.offsetHeight / 2);
-      qvLens.style.transform = `translate(${x - qvLens.offsetWidth / 2}px, ${y - qvLens.offsetHeight / 2}px)`;
-      qvLens.style.backgroundPosition = `${bx}px ${by}px`;
+      const bx = -((x * magZoom) - (qvLens?.offsetWidth || 0) / 2);
+      const by = -((y * magZoom) - (qvLens?.offsetHeight || 0) / 2);
+      if(qvLens){
+        qvLens.style.transform = `translate(${x - qvLens.offsetWidth / 2}px, ${y - qvLens.offsetHeight / 2}px)`;
+        qvLens.style.backgroundPosition = `${bx}px ${by}px`;
+      }
+      // big viewport positions around the sampled point
+      if(qvZoomBox){
+        const bx2 = -((x * magZoom) - (qvZoomBox.clientWidth / 2));
+        const by2 = -((y * magZoom) - (qvZoomBox.clientHeight / 2));
+        qvZoomBox.style.backgroundPosition = `${bx2}px ${by2}px`;
+      }
     };
-    const onEnter = () => { if(magOn) qvLens.style.display = 'block'; };
-    const onLeave = () => { qvLens.style.display = 'none'; };
+    const onEnter = () => {
+      if(magOn){
+        if(qvLens) qvLens.style.display = 'block';
+        if(qvZoomBox) qvZoomBox.style.display = 'block';
+      }
+    };
+    const onLeave = () => {
+      if(qvLens) qvLens.style.display = 'none';
+      if(qvZoomBox) qvZoomBox.style.display = 'none';
+    };
     zoomWrap.addEventListener('mousemove', onMove, { passive: true });
     zoomWrap.addEventListener('touchmove', onMove, { passive: true });
     zoomWrap.addEventListener('mouseenter', onEnter);
@@ -1452,7 +1587,8 @@
     zoomWrap.removeEventListener('mouseleave', h.onLeave);
     zoomWrap.removeEventListener('touchstart', h.onEnter);
     zoomWrap.removeEventListener('touchend', h.onLeave);
-    qvLens.style.display = 'none';
+    if(qvLens) qvLens.style.display = 'none';
+    if(qvZoomBox) qvZoomBox.style.display = 'none';
     zoomWrap.__zoomHandlers = null;
   }
 
@@ -1464,9 +1600,6 @@
     if(!qvImg) return;
     qvImg.src = src;
     if(typeof alt === 'string') qvImg.alt = alt;
-    if(qvLens){
-      qvLens.style.backgroundImage = `url(${src})`;
-    }
     updateLensBackground();
   }
 
@@ -1551,6 +1684,9 @@
     if(qvLens){
       qvLens.style.display = 'none';
     }
+    if(qvZoomBox){
+      qvZoomBox.style.display = 'none';
+    }
     if(toggle){
       toggle.checked = false;
     }
@@ -1568,6 +1704,9 @@
     }
     if(qvLens){
       qvLens.style.display = 'none';
+    }
+    if(qvZoomBox){
+      qvZoomBox.style.display = 'none';
     }
     disableQVZoom();
   }
@@ -1595,23 +1734,29 @@
   const zoom = controls.querySelector('#hcjMagZoom');
   toggle?.addEventListener('change', () => {
     magOn = toggle.checked;
-    if(qvLens){
-      if(magOn){
-        // Show lens immediately and center it
-        qvLens.style.display = 'block';
-        updateLensBackground();
-        const rect = zoomWrap?.getBoundingClientRect();
-        const lensW = qvLens.offsetWidth || 0;
-        const lensH = qvLens.offsetHeight || 0;
-        const cx = rect ? rect.width / 2 : lensW / 2;
-        const cy = rect ? rect.height / 2 : lensH / 2;
-        const bx = -((cx * magZoom) - lensW / 2);
-        const by = -((cy * magZoom) - lensH / 2);
+    if(magOn){
+      if(qvLens) qvLens.style.display = 'block';
+      if(qvZoomBox) qvZoomBox.style.display = 'block';
+      updateLensBackground();
+      const rect = zoomWrap?.getBoundingClientRect();
+      const lensW = qvLens?.offsetWidth || 0;
+      const lensH = qvLens?.offsetHeight || 0;
+      const cx = rect ? rect.width / 2 : lensW / 2;
+      const cy = rect ? rect.height / 2 : lensH / 2;
+      const bx = -((cx * magZoom) - lensW / 2);
+      const by = -((cy * magZoom) - lensH / 2);
+      if(qvLens){
         qvLens.style.transform = `translate(${cx - lensW / 2}px, ${cy - lensH / 2}px)`;
         qvLens.style.backgroundPosition = `${bx}px ${by}px`;
-      }else{
-        qvLens.style.display = 'none';
       }
+      if(qvZoomBox){
+        const bx2 = -((cx * magZoom) - (qvZoomBox.clientWidth / 2));
+        const by2 = -((cy * magZoom) - (qvZoomBox.clientHeight / 2));
+        qvZoomBox.style.backgroundPosition = `${bx2}px ${by2}px`;
+      }
+    }else{
+      if(qvLens) qvLens.style.display = 'none';
+      if(qvZoomBox) qvZoomBox.style.display = 'none';
     }
   });
   zoom?.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- ensure the live price refresher shares a single spot snapshot, exposes per-karat data, and tags cards with karat metadata for filtering
- rebuild the price pill board with explanatory copy, karat filter buttons, XAU/oz and timestamp badges, and integrate the new karat filter into existing UI logic
- add styling and quick view wiring for a desktop zoom panel that mirrors the magnifier lens and follows pointer movement

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e542dbf69c832a941b6d02c64c56fc