### PR TITLE
Add metadata for new bracelet link designs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1032,7 +1032,14 @@ const LINKS    = [
   "gold circle link.svg",
   "dual orb link.svg",
   "Arrow Link.svg",
-  "Eclipse Link.svg"
+  "Eclipse Link.svg",
+  "Barrel Link.svg",
+  "Floral Link.svg",
+  "Oblong shape with two small side circles.svg",
+  "black field with two white circular 1.svg",
+  "black field with two white circular 2.svg",
+  "black field with two white circular 3.svg",
+  "oblong shape.svg"
 ];
 
 /* Locks (terminal, left end only) */
@@ -1097,6 +1104,62 @@ const LINK_PARTS = {
     over:  "top half of Eclipse Link.svg",
     targetH: 34,
     rotate: 0
+  },
+
+  "Barrel Link.svg": {
+    base:  "Barrel Link.svg",
+    under: "bottom half of Barrel Link.svg",
+    over:  "top half of Barrel Link.svg",
+    targetH: 34,
+    rotate: 0
+  },
+
+  "Floral Link.svg": {
+    base:  "Floral Link.svg",
+    under: "bottom half of Floral Link.svg",
+    over:  "top half of Floral Link.svg",
+    targetH: 34,
+    rotate: 0
+  },
+
+  "Oblong shape with two small side circles.svg": {
+    base:  "Oblong shape with two small side circles.svg",
+    under: "bottom half of Oblong shape with two small side circles.svg",
+    over:  "top  half of Oblong shape with two small side circles.svg",
+    targetH: 34,
+    rotate: 0
+  },
+
+  "black field with two white circular 1.svg": {
+    base:  "black field with two white circular 1.svg",
+    under: "bottom half of black field with two white circular 1.svg",
+    over:  "top  half of black field with two white circular 1.svg",
+    targetH: 34,
+    rotate: 0
+  },
+
+  "black field with two white circular 2.svg": {
+    base:  "black field with two white circular 2.svg",
+    under: "bottom half of black field with two white circular 2.svg",
+    over:  "top half of black field with two white circular 2.svg",
+    targetH: 34,
+    rotate: 0
+  },
+
+  "black field with two white circular 3.svg": {
+    base:  "black field with two white circular 3.svg",
+    under: "bottom half of black field with two white circular 3.svg",
+    over:  "top half of black field with two white circular 3.svg",
+    targetH: 34,
+    rotate: 0
+  },
+
+  "oblong shape.svg": {
+    base:  "oblong shape.svg",
+    under: "bottom half of oblong shape.svg",
+    over:  "top half of oblong shape.svg",
+    targetH: 34,
+    rotate: 0
   }
 };
 
@@ -1132,6 +1195,13 @@ const WEIGHTS = {
   "dual orb link.svg": 0.12,
   "Arrow Link.svg": 0.10,
   "Eclipse Link.svg": 0.10,
+  "Barrel Link.svg": 0.10,
+  "Floral Link.svg": 0.10,
+  "Oblong shape with two small side circles.svg": 0.10,
+  "black field with two white circular 1.svg": 0.10,
+  "black field with two white circular 2.svg": 0.10,
+  "black field with two white circular 3.svg": 0.10,
+  "oblong shape.svg": 0.10,
   "dolphin fish lock.svg": 0.12,
   "__default_pendant": 0.30,
   "__default_link": 0.10


### PR DESCRIPTION
## Summary
- add the newly uploaded link SVGs to the bracelet configurator
- wire up top/bottom slice metadata for each new link design
- assign placeholder weights so the estimator recognizes the new parts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e54c421560832ab9a066a7ac19fc7f